### PR TITLE
chore: don't auto-close noncompliant PRs

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     types:
-      - opened
       - edited
+      - opened
       - reopened
       - synchronize
 
@@ -15,3 +15,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: mtfoley/pr-compliance-action@main
+        with:
+          body-auto-close: false


### PR DESCRIPTION
Amusing that https://github.com/JoshuaKGoldberg/template-typescript-node-package/pull/13 was closed automatically.