### PR TITLE
docs: more badges

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,4 @@
 {
-	"config": "markdownlint/style/all.json",
 	"first-line-h1": false,
 	"no-hard-tabs": false,
 	"no-inline-html": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
+	"config": "markdownlint/style/all.json",
 	"first-line-h1": false,
 	"no-hard-tabs": false,
 	"no-inline-html": false,

--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@
 <p align="center">
 	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 	<a href="#contributors-">
-		<img alt="All Contributors" src="https://img.shields.io/badge/all_contributors-1-14cc21.svg" />
+		<img alt="All Contributors" src="https://img.shields.io/badge/all_contributors-1-21bb42.svg" />
 	</a>
 	<!-- ALL-CONTRIBUTORS-BADGE:END -->
 	<a href="https://github.com/JoshuaKGoldberg/template-typescript-node-package/actions/workflows/build.yml">
 		<img alt="Build Status: Build Passing" src="https://github.com/JoshuaKGoldberg/template-typescript-node-package/actions/workflows/build.yml/badge.svg" />
 	</a>
-	<img alt="Code Style: Prettier" src="https://img.shields.io/badge/code_style-prettier-14cc21.svg" />
-	<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-14cc21.svg" />
+	<img alt="Code Style: Prettier" src="https://img.shields.io/badge/code_style-prettier-21bb42.svg" />
+	<a href="https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CODE_OF_CONDUCT.md">
+		<img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-contributor_covenant-21bb42" />
+	</a>
+	<a href="https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/LICENSE.md">
+	    <img alt="License: MIT" src="https://img.shields.io/github/license/JoshuaKGoldberg/template-typescript-node-package?color=21bb42">
+    </a>
+	<a href="https://github.com/sponsors/JoshuaKGoldberg">
+    	<img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" />
+    </a>
+    <img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
+
 </p>
 
 ## Usage


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #28
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I tried to get the manually colored badges to be the same color as the GitHub badge. But, the build badge is not super useful IMO. Removed.
