### PR TITLE
chore: add lint.yml to run ESLint in CI

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,7 +4,6 @@ description: Prepares the repo for a typical CI job
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         node-version: "18"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/prepare
+      - run: yarn lint


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #46 
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Copies `prettier.yml` to a new `lint.yml` workflow that runs ESLint.

Also removes a duplicate `actions/checkout@v3` from the prepare script. I think it's not needed?