### PR TITLE
fix: corrected .js and main imports for Node importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 	"lint-staged": {
 		"*": "prettier --ignore-unknown --write"
 	},
+	"main": "./dist/index.js",
 	"name": "template-typescript-node-package",
 	"scripts": {
 		"build": "tsc",

--- a/src/greet.ts
+++ b/src/greet.ts
@@ -1,4 +1,4 @@
-import { GreetOptions } from "./types";
+import { GreetOptions } from "./types.js";
 
 export function greet(options: GreetOptions | string) {
 	const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./greet.js";
-export * from "./types";
+export * from "./types.js";


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #60
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`main` is needed to be `import`ed / `require`d: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#main

...and `---/types` does not exist, just `---/types.js`.
