### PR TITLE
chore: move "plugin:typescript-sort-keys/recommended" to override scope

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,6 @@
 module.exports = {
 	extends: [
 		"eslint:recommended",
-		"plugin:typescript-sort-keys/recommended",
 		"prettier",
 	],
 	overrides: [
@@ -9,6 +8,7 @@ module.exports = {
 			extends: [
 				"plugin:@typescript-eslint/recommended",
 				"plugin:@typescript-eslint/recommended-requiring-type-checking",
+				"plugin:typescript-sort-keys/recommended",
 				"plugin:@typescript-eslint/strict",
 			],
 			files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #69 
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Moves TypeScript interface & type key sorting in ESLint to an override scope so that it only applies to TypeScript files.