### PR TITLE
docs: add codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 		<img alt="All Contributors" src="https://img.shields.io/badge/all_contributors-1-21bb42.svg" />
 	</a>
 	<!-- ALL-CONTRIBUTORS-BADGE:END -->
-	<img alt="Code Style: Prettier" src="https://img.shields.io/badge/code_style-prettier-21bb42.svg" />
+	<a href="https://codecov.io/gh/JoshuaKGoldberg/template-typescript-node-package" > 
+		<img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/template-typescript-node-package/branch/main/graph/badge.svg?token=eVIFY4MhfQ"/>
+	</a>
 	<a href="https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CODE_OF_CONDUCT.md">
-		<img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-contributor_covenant-21bb42" />
+		<img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" />
 	</a>
 	<a href="https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/LICENSE.md">
 	    <img alt="License: MIT" src="https://img.shields.io/github/license/JoshuaKGoldberg/template-typescript-node-package?color=21bb42">
@@ -18,6 +20,7 @@
 	<a href="https://github.com/sponsors/JoshuaKGoldberg">
     	<img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" />
     </a>
+	<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
     <img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
 </p>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 		<img alt="All Contributors" src="https://img.shields.io/badge/all_contributors-1-21bb42.svg" />
 	</a>
 	<!-- ALL-CONTRIBUTORS-BADGE:END -->
-	<a href="https://codecov.io/gh/JoshuaKGoldberg/template-typescript-node-package" > 
+	<a href="https://codecov.io/gh/JoshuaKGoldberg/template-typescript-node-package" >
 		<img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/template-typescript-node-package/branch/main/graph/badge.svg?token=eVIFY4MhfQ"/>
 	</a>
 	<a href="https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CODE_OF_CONDUCT.md">

--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,5 @@
 {
 	"dictionaries": ["typescript"],
 	"ignorePaths": [".github", "dist", "node_modules", "pnpm-lock.yaml"],
-	"words": ["commitlint", "lcov"]
+	"words": ["Codecov", "commitlint", "lcov"]
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: continues #79 
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Quick lil docs touchup for code coverage in the README.md. Rewords a couple of existing badges so the images all fit on one line in the common GitHub Markdown preview width.