### PR TITLE
fix: properly separated typed and untyped linting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,6 +23,13 @@ module.exports = {
 				"plugin:@typescript-eslint/strict",
 			],
 			files: ["**/*.{ts,tsx}"],
+			parserOptions: {
+				project: "./tsconfig.eslint.json",
+			},
+			rules: {
+				// These off-by-default rules work well for this repo and we like them on.
+				"deprecation/deprecation": "error",
+			},
 		},
 		{
 			files: "*.json",
@@ -41,10 +48,6 @@ module.exports = {
 		},
 	],
 	parser: "@typescript-eslint/parser",
-	parserOptions: {
-		tsconfigRootDir: __dirname,
-		project: ["./tsconfig.json"],
-	},
 	plugins: [
 		"@typescript-eslint",
 		"deprecation",
@@ -57,7 +60,6 @@ module.exports = {
 	root: true,
 	rules: {
 		// These off-by-default rules work well for this repo and we like them on.
-		"deprecation/deprecation": "error",
 		"no-only-tests/no-only-tests": "error",
 		"simple-import-sort/exports": "error",
 		"simple-import-sort/imports": "error",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["."]
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #91
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Two fixes:
* Adds & uses a `tsconfig.eslint.json` that includes all files, not just those under `src`
* Moves `parserOptions.project` and the typed `deprecation/deprecation` rule to just TypeScript source files, not JS