### PR TITLE
chore: output files to lib, not dist

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-dist
+lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 coverage/
-dist/
+lib/
 node_modules/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,3 @@
 .github/CODE_OF_CONDUCT.md
-dist/
+lib/
 node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,11 @@
+.*
+./*.js
 .github/
 .vscode/
+*.config.*
 *.test.*
 coverage/
+cspell.json
 pnpm-lock.yaml
+tsconfig.*.json
+tsconfig*.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
-dist/
+lib/
 pnpm-lock.yaml

--- a/cspell.json
+++ b/cspell.json
@@ -2,7 +2,7 @@
 	"dictionaries": ["typescript"],
 	"ignorePaths": [
 		".github",
-		"dist",
+		"lib",
 		"node_modules",
 		"pnpm-lock.yaml",
 		"script/*.json"

--- a/package.json
+++ b/package.json
@@ -45,9 +45,13 @@
 	"lint-staged": {
 		"*": "prettier --ignore-unknown --write"
 	},
-	"main": "./dist/index.js",
+	"main": "./lib/index.js",
 	"name": "template-typescript-node-package",
 	"packageManager": "pnpm@7.16.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/JoshuaKGoldberg/template-typescript-node-package"
+	},
 	"scripts": {
 		"build": "tsc",
 		"format": "prettier \"**/*\" --ignore-unknown",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,11 @@
 		"declarationMap": true,
 		"esModuleInterop": true,
 		"moduleResolution": "node",
-		"outDir": "dist",
+		"outDir": "lib",
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
 		"target": "ES2021"
-	}
+	},
+	"include": ["src"]
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #93
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Find-and-replaces `dist` to `lib`.

Also adds some more files to `.npmignore` while I'm in the area.