### PR TITLE
chore: set assets to [], not false

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,7 @@
 		[
 			"@semantic-release/git",
 			{
-				"assets": false,
+				"assets": [],
 				"message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
 			}
 		]


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #84
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In lieu of https://github.com/semantic-release/git/issues/280 being fixed.

I still want `package.json` to be committed whenever a new version is published, just not ... any other assets.