### PR TITLE
chore: include package.json in semantic-release/git

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,7 @@
 		[
 			"@semantic-release/git",
 			{
-				"assets": [],
+				"assets": ["package.json"],
 				"message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
 			}
 		]


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #103
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Does what the issue describes: includes `package.json` as a committed file.