### PR TITLE
fix: temporarily disable branch protections for release-it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,17 @@ jobs:
       - env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+      - name: Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.7
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm release-it
+      - name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.7
+        if: always()
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #81
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses https://github.com/marketplace/actions/branch-protection-bot to temporarily disable the default branch's branch protections just when running `release-it`.