### PR TITLE
chore: ignore coverage/ directory for linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
+coverage
 lib


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #112
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

As the issue describes, adds `coverage` to the ignored directories list.