### PR TITLE
fix: corrected description quote in setup script

### DIFF
--- a/script/setup.js
+++ b/script/setup.js
@@ -155,7 +155,7 @@ try {
 	console.log();
 	console.log(chalk.gray`Hydrating repository settings...`);
 
-	await $`gh repo edit --delete-branch-on-merge --description "${description}" --enable-auto-merge --enable-rebase-merge=false --enable-squash-merge`;
+	await $`gh repo edit --delete-branch-on-merge --description ${description} --enable-auto-merge --enable-rebase-merge=false --enable-squash-merge`;
 
 	console.log(chalk.gray`✔️ Done.`);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #122
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Goes by the zx docs saying you don't need to explicitly `"` escape out inputs. https://github.com/google/zx#command-