### PR TITLE
fix: corrected allcontributors setup import path with fs

### DIFF
--- a/script/setup.js
+++ b/script/setup.js
@@ -3,10 +3,6 @@ import chalk from "chalk";
 import { promises as fs } from "fs";
 import prettier from "prettier";
 
-import existingContributors from "../.all-contributorsrc.json" assert { type: "json" };
-import existingPackage from "../package.json" assert { type: "json" };
-import outcomeLabels from "./labels.json" assert { type: "json" };
-
 let caughtError;
 
 try {
@@ -87,8 +83,19 @@ try {
 	console.log();
 	console.log(chalk.gray`Hydrating package metadata locally...`);
 
+	async function readFileAsJSON(filePath) {
+		return JSON.parse((await fs.readFile(filePath)).toString());
+	}
+
+	const [existingContributors, existingPackage, outcomeLabels] =
+		await Promise.all([
+			readFileAsJSON("./.all-contributorsrc"),
+			readFileAsJSON("./package.json"),
+			readFileAsJSON("./script/labels.json"),
+		]);
+
 	await fs.writeFile(
-		"./.all-contributorsrc.json",
+		"./.all-contributorsrc",
 		prettier.format(
 			JSON.stringify({
 				...existingContributors,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #117
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Turns out the file path that's being imported is `.allcontributorsrc`, not `.allcontributorsrc.json`. ES Module JSON imports don't support importing files that don't have the `.json` extension. 🤷 

So this switches to using `JSON.parse` and `fs.readFile`.