### PR TITLE
feat: clear CHANGELOG.md and local Git tags in setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### [1.20.1](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.20.0...v1.20.1) (2022-12-15)
+# Changelog
+
+## [1.20.1](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.20.0...v1.20.1) (2022-12-15)
 
 ### Bug Fixes
 
@@ -28,8 +30,6 @@
 ### Features
 
 - switch from semantic-release to release-it ([#110](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/110)) ([c0fcbf4](https://github.com/JoshuaKGoldberg/template-typescript-node-package/commit/c0fcbf46718ee6ad0e3582b1f01e2910a3da847d))
-
-# Changelog
 
 ## [1.7.0](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.6.0...v1.7.0) (2022-12-14)
 

--- a/script/setup.js
+++ b/script/setup.js
@@ -122,7 +122,7 @@ try {
 		[/"setup": ".*",/, ``, "./package.json"],
 		[
 			`"version": "${existingPackage.version}"`,
-			`"version": "0.0.1"`,
+			`"version": "0.0.0"`,
 			"./package.json",
 		],
 		[/## Explainer.*## Usage/s, `## Usage`, "./README.md"],
@@ -138,6 +138,23 @@ try {
 	]) {
 		await replace({ files, from, to });
 	}
+
+	console.log(chalk.gray`✔️ Done.`);
+
+	console.log();
+	console.log(chalk.gray`Clearing CHANGELOG.md...`);
+
+	await fs.writeFile(
+		"./CHANGELOG.md",
+		prettier.format(`# Changelog`, { parser: "markdown" })
+	);
+
+	console.log(chalk.gray`✔️ Done.`);
+
+	console.log();
+	console.log(chalk.gray`Deleting local git tags...`);
+
+	await $`git tag -d $(git tag -l)`;
 
 	console.log(chalk.gray`✔️ Done.`);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #121
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies two more things in the setup script:

* Runs `git tag -d $(git tag -l)` to delete _local_ Git tags (they can be retrieved again with `git fetch`
* Resets `CHANGELOG.md` to just `# Changelog`