### PR TITLE
feat: add header to CHANGELOG.md

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -8,6 +8,7 @@
 	},
 	"plugins": {
 		"@release-it/conventional-changelog": {
+			"header": "# Changelog",
 			"infile": "CHANGELOG.md",
 			"preset": "conventionalcommits"
 		}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,18 @@
+# Changelog
+
 ## [1.21.0](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.20.2...v1.21.0) (2022-12-15)
 
 ### Features
 
 - clear CHANGELOG.md and local Git tags in setup ([#125](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/125)) ([9ed5f45](https://github.com/JoshuaKGoldberg/template-typescript-node-package/commit/9ed5f452f1de3841647cfff594676819a3e416e5))
 
-# Changelog
-
-### [1.20.2](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.20.1...v1.20.2) (2022-12-15)
+## [1.20.2](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.20.1...v1.20.2) (2022-12-15)
 
 ### Bug Fixes
 
 - corrected allcontributors setup import path with fs ([#124](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/124)) ([2506907](https://github.com/JoshuaKGoldberg/template-typescript-node-package/commit/25069072073b3b26b039aaf2f6b6dea9cd1cd8b2))
 
-### [1.20.1](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.20.0...v1.20.1) (2022-12-15)
+## [1.20.1](https://github.com/JoshuaKGoldberg/template-typescript-node-package/compare/v1.20.0...v1.20.1) (2022-12-15)
 
 ### Bug Fixes
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #126
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adjusts the existing `CHANGELOG.md` to correct some `###`s, and sets `# Changelog` as the header in the release-it settings.