### PR TITLE
fix: only append README.md notice once in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ Thanks! 💖
 <!-- spellchecker: enable -->
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
+<!-- You can remove this notice if you don't want it 🙂 no worries! -->
+
+> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [template-typescript-node-package](https://github.com/JoshuaKGoldberg/template-typescript-node-package).

--- a/script/setup.js
+++ b/script/setup.js
@@ -126,17 +126,20 @@ try {
 			"./package.json",
 		],
 		[/## Explainer.*## Usage/s, `## Usage`, "./README.md"],
-		[
-			"<!-- ALL-CONTRIBUTORS-LIST:END -->",
-			`<!-- ALL-CONTRIBUTORS-LIST:END -->
-
-<!-- You can remove this notice if you don't want it 🙂 no worries! -->
-
-> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [template-typescript-node-package](https://github.com/JoshuaKGoldberg/template-typescript-node-package).`,
-			"./README.md",
-		],
 	]) {
 		await replace({ files, from, to });
+	}
+
+	const endOfReadmeNotice = `
+
+	<!-- You can remove this notice if you don't want it 🙂 no worries! -->
+	
+	> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [template-typescript-node-package](https://github.com/JoshuaKGoldberg/template-typescript-node-package).`;
+
+	if (
+		!(await fs.readFile("./README.md")).toString().includes(endOfReadmeNotice)
+	) {
+		await fs.appendFile("./README.md", endOfReadmeNotice);
 	}
 
 	console.log(chalk.gray`✔️ Done.`);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #129
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses `fs.appendFile` instead of the more nuanced `replace-in-file` approach.