### PR TITLE
fix: correct renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,5 @@
 	"automerge": true,
 	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
-	"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
 	"stabilityDays": 3
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the erroneous `matchUpdateTypes`. Let's just automerge everything!

IIRC I'd long ago gotten a message somewhere about `matchUpdateTypes` being necessary. 🤷 