### PR TITLE
chore: end-to-end test setup script

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,0 +1,15 @@
+name: Test Setup Script
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/prepare
+      - run: pnpm run setup:test

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"lint:spelling": "cspell \"**\" \".github/**/*\"",
 		"prepare": "husky install",
 		"setup": "npx --yes zx --quiet script/setup.js",
-		"setup:test": "npx --yes zx --quiet script/setup.test.js",
+		"setup:test": "npx --yes zx --quiet script/setup-test-e2e.js",
 		"test": "vitest"
 	},
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"lint:spelling": "cspell \"**\" \".github/**/*\"",
 		"prepare": "husky install",
 		"setup": "npx --yes zx --quiet script/setup.js",
+		"setup:test": "npx --yes zx --quiet script/setup.test.js",
 		"test": "vitest"
 	},
 	"type": "module",

--- a/script/setup-test-e2e.js
+++ b/script/setup-test-e2e.js
@@ -9,7 +9,9 @@ const owner = "NewOwnerTest";
 const title = "New Title Test";
 const repository = "new-repository-test";
 
-await $`pnpm run setup --description ${description} --owner ${owner} --title ${title} --repository ${repository} --skip-api`;
+const result =
+	await $`pnpm run setup --description ${description} --owner ${owner} --title ${title} --repository ${repository} --skip-api`;
+console.log({ result });
 
 const newPackageJson = JSON.parse(
 	(await fs.readFile("./package.json")).toString()

--- a/script/setup.js
+++ b/script/setup.js
@@ -23,18 +23,6 @@ try {
 	);
 	console.log();
 
-	console.log(chalk.gray`Checking gh auth status...`);
-	let auth;
-	try {
-		await $`gh auth status`;
-		auth = (await $`gh auth token`).toString().trim();
-	} catch (error) {
-		throw new Error(error.stderr);
-	}
-
-	console.log(chalk.gray`✔️ Done.`);
-	console.log();
-
 	const { values } = parseArgs({
 		args: process.argv.slice(2),
 		options: {
@@ -172,6 +160,18 @@ try {
 	if (skipApi) {
 		console.log(chalk.gray`➖ Skipping API hydration.`);
 	} else {
+		console.log(chalk.gray`Checking gh auth status...`);
+		let auth;
+		try {
+			await $`gh auth status`;
+			auth = (await $`gh auth token`).toString().trim();
+		} catch (error) {
+			throw new Error(error.stderr);
+		}
+
+		console.log(chalk.gray`✔️ Done.`);
+		console.log();
+
 		console.log(chalk.gray`Hydrating repository labels...`);
 
 		const existingLabels = JSON.parse(

--- a/script/setup.js
+++ b/script/setup.js
@@ -259,12 +259,12 @@ try {
 	console.log(chalk.red(error.stack));
 	caughtError = error;
 } finally {
-	// console.log();
-	// console.log(
-	// 	chalk.gray`Removing devDependency packages only used for setup...`
-	// );
-	// await $`pnpm remove enquirer octokit replace-in-file -D`;
-	// console.log(chalk.gray`✔️ Done.`);
+	console.log();
+	console.log(
+		chalk.gray`Removing devDependency packages only used for setup...`
+	);
+	await $`pnpm remove enquirer octokit replace-in-file -D`;
+	console.log(chalk.gray`✔️ Done.`);
 }
 
 console.log();

--- a/script/setup.js
+++ b/script/setup.js
@@ -42,6 +42,7 @@ try {
 			owner: { type: "string" },
 			repository: { type: "string" },
 			title: { type: "string" },
+			"skip-api": { type: "boolean" },
 		},
 		tokens: true,
 		strict: false,
@@ -78,6 +79,11 @@ try {
 	const description = await getPrefillOrPromptedValue(
 		"description",
 		"How would you describe the new package?"
+	);
+
+	const skipApi = await getPrefillOrPromptedValue(
+		"skip-api",
+		"Whether to skip calling the GitHub API (effectively making this a local-only change)."
 	);
 
 	console.log();
@@ -118,6 +124,7 @@ try {
 		["JoshuaKGoldberg", owner],
 		["template-typescript-node-package", repository],
 		[/"setup": ".*",/, ``, "./package.json"],
+		[/"setup:test": ".*",/, ``, "./package.json"],
 		[
 			`"version": "${existingPackage.version}"`,
 			`"version": "0.0.0"`,
@@ -159,99 +166,105 @@ try {
 
 	console.log(chalk.gray`✔️ Done.`);
 
-	console.log();
-	console.log(chalk.gray`Hydrating repository labels...`);
-
-	const existingLabels = JSON.parse(
-		(await $`gh label list --json name`).stdout || "[]"
-	);
-
-	for (const outcome of outcomeLabels) {
-		const action = existingLabels.some(
-			(existing) => existing.name === outcome.name
-		)
-			? "edit"
-			: "create";
-		await $`gh label ${action} ${outcome.name} --color ${outcome.color} --description ${outcome.description}`;
-	}
-
 	console.log(chalk.gray`✔️ Done.`);
-
 	console.log();
-	console.log(chalk.gray`Hydrating initial repository settings...`);
 
-	const octokit = new Octokit({ auth });
+	if (skipApi) {
+		console.log(chalk.gray`➖ Skipping API hydration.`);
+	} else {
+		console.log(chalk.gray`Hydrating repository labels...`);
 
-	octokit.rest.repos.update({
-		allow_auto_merge: true,
-		allow_rebase_merge: false,
-		allow_squash_merge: true,
-		default_branch: "main",
-		delete_branch_on_merge: true,
-		description,
-		has_wiki: false,
-		owner,
-		repo: repository,
-	});
+		const existingLabels = JSON.parse(
+			(await $`gh label list --json name`).stdout || "[]"
+		);
 
-	console.log();
-	console.log(chalk.gray`Hydrating branch protection settings...`);
+		for (const outcome of outcomeLabels) {
+			const action = existingLabels.some(
+				(existing) => existing.name === outcome.name
+			)
+				? "edit"
+				: "create";
+			await $`gh label ${action} ${outcome.name} --color ${outcome.color} --description ${outcome.description}`;
+		}
+		console.log(chalk.gray`✔️ Done.`);
 
-	// Note: keep this inline script in sync with .github/workflows/release.yml!
-	// Todo: it would be nice to not have two sources of truth...
-	// https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/145
-	await octokit.request(
-		`PUT /repos/${owner}/${repository}/branches/main/protection`,
-		{
-			allow_deletions: false,
-			allow_force_pushes: true,
-			allow_fork_pushes: false,
-			allow_fork_syncing: true,
-			block_creations: false,
-			branch: "main",
-			enforce_admins: false,
+		console.log();
+		console.log(chalk.gray`Hydrating initial repository settings...`);
+
+		const octokit = new Octokit({ auth });
+
+		octokit.rest.repos.update({
+			allow_auto_merge: true,
+			allow_rebase_merge: false,
+			allow_squash_merge: true,
+			default_branch: "main",
+			delete_branch_on_merge: true,
+			description,
+			has_wiki: false,
 			owner,
 			repo: repository,
-			required_conversation_resolution: true,
-			required_linear_history: false,
-			required_pull_request_reviews: null,
-			required_status_checks: {
-				checks: [
-					{ context: "build" },
-					{ context: "compliance" },
-					{ context: "lint" },
-					{ context: "markdown" },
-					{ context: "package" },
-					{ context: "packages" },
-					{ context: "prettier" },
-					{ context: "prune" },
-					{ context: "spelling" },
-					{ context: "test" },
-				],
-				strict: false,
-			},
-			restrictions: null,
-		}
-	);
+		});
 
-	console.log(chalk.gray`✔️ Done.`);
+		console.log();
+		console.log(chalk.gray`Hydrating branch protection settings...`);
+
+		// Note: keep this inline script in sync with .github/workflows/release.yml!
+		// Todo: it would be nice to not have two sources of truth...
+		// https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/145
+		await octokit.request(
+			`PUT /repos/${owner}/${repository}/branches/main/protection`,
+			{
+				allow_deletions: false,
+				allow_force_pushes: true,
+				allow_fork_pushes: false,
+				allow_fork_syncing: true,
+				block_creations: false,
+				branch: "main",
+				enforce_admins: false,
+				owner,
+				repo: repository,
+				required_conversation_resolution: true,
+				required_linear_history: false,
+				required_pull_request_reviews: null,
+				required_status_checks: {
+					checks: [
+						{ context: "build" },
+						{ context: "compliance" },
+						{ context: "lint" },
+						{ context: "markdown" },
+						{ context: "package" },
+						{ context: "packages" },
+						{ context: "prettier" },
+						{ context: "prune" },
+						{ context: "spelling" },
+						{ context: "test" },
+					],
+					strict: false,
+				},
+				restrictions: null,
+			}
+		);
+
+		console.log(chalk.gray`✔️ Done.`);
+	}
 
 	console.log();
 	console.log(chalk.gray`Removing setup script...`);
 
 	await fs.rm("./script", { force: true, recursive: true });
+	await fs.rm(".github/workflows/setup.yml");
 
 	console.log(chalk.gray`✔️ Done.`);
 } catch (error) {
 	console.log(chalk.red(error.stack));
 	caughtError = error;
 } finally {
-	console.log();
-	console.log(
-		chalk.gray`Removing devDependency packages only used for setup...`
-	);
-	await $`pnpm remove enquirer octokit replace-in-file -D`;
-	console.log(chalk.gray`✔️ Done.`);
+	// console.log();
+	// console.log(
+	// 	chalk.gray`Removing devDependency packages only used for setup...`
+	// );
+	// await $`pnpm remove enquirer octokit replace-in-file -D`;
+	// console.log(chalk.gray`✔️ Done.`);
 }
 
 console.log();

--- a/script/setup.test.js
+++ b/script/setup.test.js
@@ -1,0 +1,19 @@
+/* global $ */
+
+import { strict as assert } from "node:assert";
+
+import { promises as fs } from "fs";
+
+const description = "New Description Test";
+const owner = "NewOwnerTest";
+const title = "New Title Test";
+const repository = "new-repository-test";
+
+await $`pnpm run setup --description ${description} --owner ${owner} --title ${title} --repository ${repository} --skip-api`;
+
+const newPackageJson = JSON.parse(
+	(await fs.readFile("./package.json")).toString()
+);
+
+assert.equal(newPackageJson.description, description);
+assert.equal(newPackageJson.name, repository);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #118
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a rudimentary end-to-end test to the setup script. It also gets removed on setup.

In theory this could also test other parts of setup: that the name in files is replaced, that the setup script is removed, etc. But I opted not to for now.