### PR TITLE
fix: run build prior to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/prepare
+      - run: pnpm build
       - run: git config user.name "${GITHUB_ACTOR}"
       - run: git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
       - env:

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ coverage/
 cspell.json
 pnpm-lock.yaml
 tsconfig*.json
+src

--- a/.npmignore
+++ b/.npmignore
@@ -7,5 +7,5 @@
 coverage/
 cspell.json
 pnpm-lock.yaml
-tsconfig*.json
 src
+tsconfig*.json

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 		clearMocks: true,
 		coverage: {
 			all: true,
+			exclude: ["lib"],
 			include: ["src"],
 			reporter: ["html", "lcov"],
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to template-typescript-node-package! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #162
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR adds in a build step to the `release.yml` so the build artefacts exist for publishing. It also excludes `src` from publishing as it bloats package size and isn't used.

PR requested here: https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/147#issuecomment-1364555919

It also ensure vitest doesn't try and run tests in the `lib` folder.