### PR TITLE
feat: added 'status: ' prefix to 'accepting prs' and 'wontfix' labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Otherwise we may not be able to review your PR. -->
 ## PR Checklist
 
 - [ ] Addresses an existing open issue: fixes #000
-- [ ] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
+- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
 - [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken
 
 ## Overview

--- a/script/labels.json
+++ b/script/labels.json
@@ -1,10 +1,5 @@
 [
 	{
-		"color": "0E8A16",
-		"description": "Please, send a pull request to resolve this!",
-		"name": "accepting prs"
-	},
-	{
 		"color": "0075ca",
 		"description": "Improvements or additions to docs",
 		"name": "area: documentation"
@@ -30,6 +25,11 @@
 		"name": "invalid"
 	},
 	{
+		"color": "0E8A16",
+		"description": "Please, send a pull request to resolve this!",
+		"name": "status: accepting prs"
+	},
+	{
 		"color": "#ddcccc",
 		"description": "Waiting for something else to be resolved",
 		"name": "status: blocked"
@@ -50,6 +50,11 @@
 		"name": "status: waiting for author"
 	},
 	{
+		"color": "ffffff",
+		"description": "This will not be worked on",
+		"name": "status: wontfix"
+	},
+	{
 		"color": "d73a4a",
 		"description": "Something isn't working",
 		"name": "type: bug"
@@ -63,10 +68,5 @@
 		"color": "d876e3",
 		"description": "Further information is requested",
 		"name": "type: question"
-	},
-	{
-		"color": "ffffff",
-		"description": "This will not be worked on",
-		"name": "wontfix"
 	}
 ]


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #197
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates the PR template and setup script `labels.json`