### PR TITLE
fix: include .jsonc files in the override files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,7 +32,7 @@ module.exports = {
 			},
 		},
 		{
-			files: "*.json",
+			files: ["*.json", "*.jsonc"],
 			excludedFiles: ["package.json"],
 			parser: "jsonc-eslint-parser",
 			rules: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #238
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changed the override files in .eslintrc.cjs to include both ".json" and ".jsonc" files and checked for any lint issues.
