### PR TITLE
chore: comment on prs and issues with release info

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           comment-template: |
-            :tada: This PR is included in version {release_link} :tada:
+            :tada: This is included in version {release_link} :tada:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,16 @@
+name: Post-release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  post_release:
+    name: Comment on relevant PRs and issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: apexskier/github-release-commenter@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-template: |
+            :tada: This PR is included in version {release_link} :tada:


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to template-typescript-node-package! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #230 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Used https://github.com/apexskier/github-release-commenter action to add comments about release to related PRs and issues.
Functionality mentioned in the linked issue comes from `semantic-release` https://github.com/h6s-dev/h6s/blob/80f12bf7c7f75d974aadb39a9b6823c5d589513c/.releaserc.json#L16 

I saw it was replaced by `release-it` in this repo so we needed another solution.

Working example:
[Workflow file](https://github.com/winglang/wing/blob/e7551dcda97eab78aa17a9bc08385ff78d8503fe/.github/workflows/release-commenter.yml#L13)

[PR comment](https://github.com/winglang/wing/pull/1540#issuecomment-1431398410)
[Issue comment](https://github.com/winglang/wing/issues/1390#issuecomment-1412924184)