### PR TITLE
ci: add allcontributors to ignore-authors

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           body-auto-close: false
           ignore-authors: |
+            allcontributors
             renovate
             renovate[bot]
           ignore-team-members: false


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #228
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Add `allcontributors` to `ignore-authors` in compliance job for pull requests
