### PR TITLE
chore: enable contributors sort alphabetically rule in .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -96,6 +96,7 @@
     }
   ],
   "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": true,
   "files": [
     "README.md"
   ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #164
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
Enable the `all-contibutors` rule to sort contributors alphabetically.

