### PR TITLE
fix: remove chalk dependency after pnpm setup

### DIFF
--- a/script/setup.js
+++ b/script/setup.js
@@ -270,7 +270,7 @@ try {
 	console.log(
 		chalk.gray`Removing devDependency packages only used for setup...`
 	);
-	await $`pnpm remove enquirer octokit replace-in-file -D`;
+	await $`pnpm remove chalk enquirer octokit replace-in-file -D`;
 	console.log(chalk.gray`✔️ Done.`);
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #193
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Add `chalk` to `pnpm remove` at the end of setup so that it is installed after running setup.
