### PR TITLE
fix: replace all instances of old strings in setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,3 @@ Thanks! 💖
 <!-- spellchecker: enable -->
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
-
-<!-- You can remove this notice if you don't want it 🙂 no worries! -->
-
-> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [template-typescript-node-package](https://github.com/JoshuaKGoldberg/template-typescript-node-package).

--- a/script/setup.js
+++ b/script/setup.js
@@ -1,4 +1,5 @@
 /* global $ */
+import { EOL } from "node:os";
 import { parseArgs } from "node:util";
 
 import chalk from "chalk";
@@ -6,7 +7,6 @@ import { promises as fs } from "fs";
 import { Octokit } from "octokit";
 import prettier from "prettier";
 import replace from "replace-in-file";
-import { EOL } from "node:os";
 
 const { prompt } = require("enquirer");
 

--- a/script/setup.js
+++ b/script/setup.js
@@ -6,6 +6,7 @@ import { promises as fs } from "fs";
 import { Octokit } from "octokit";
 import prettier from "prettier";
 import replace from "replace-in-file";
+import { EOL } from "node:os";
 
 const { prompt } = require("enquirer");
 
@@ -107,18 +108,18 @@ try {
 	);
 
 	for (const [from, to, files = ["./.github/**/*", "./*.*"]] of [
-		[existingPackage.description, description],
-		["Template TypeScript Node Package", title],
-		["JoshuaKGoldberg", owner],
-		["template-typescript-node-package", repository],
-		[/"setup": ".*",/, ``, "./package.json"],
-		[/"setup:test": ".*",/, ``, "./package.json"],
+		[new RegExp(existingPackage.description, "g"), description],
+		[/Template TypeScript Node Package/g, title],
+		[/JoshuaKGoldberg/g, owner],
+		[/template-typescript-node-package/g, repository],
+		[/"setup": ".*",/g, ``, "./package.json"],
+		[/"setup:test": ".*",/g, ``, "./package.json"],
 		[
-			`"version": "${existingPackage.version}"`,
+			new RegExp(`"version": "${existingPackage.version}"`, "g"),
 			`"version": "0.0.0"`,
 			"./package.json",
 		],
-		[/## Explainer.*## Usage/s, `## Usage`, "./README.md"],
+		[/## Explainer.*## Usage/gs, `## Usage`, "./README.md"],
 		[
 			`["src/index.ts!", "script/setup*.js"]`,
 			`"src/index.ts!"`,
@@ -129,17 +130,27 @@ try {
 		await replace({ files, from, to });
 	}
 
-	const endOfReadmeNotice = `
+	await fs.writeFile(
+		".all-contributorsrc",
+		prettier.format(
+			JSON.stringify({
+				...JSON.parse((await fs.readFile(".all-contributorsrc")).toString()),
+				projectName: repository,
+				projectOwner: owner,
+			}),
+			{ parser: "json" }
+		)
+	);
 
-	<!-- You can remove this notice if you don't want it 🙂 no worries! -->
-	
-	> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [template-typescript-node-package](https://github.com/JoshuaKGoldberg/template-typescript-node-package).`;
+	const endOfReadmeNotice = [
+		``,
+		`<!-- You can remove this notice if you don't want it 🙂 no worries! -->`,
+		``,
+		`> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [template-typescript-node-package](https://github.com/JoshuaKGoldberg/template-typescript-node-package).`,
+		``,
+	].join(EOL);
 
-	if (
-		!(await fs.readFile("./README.md")).toString().includes(endOfReadmeNotice)
-	) {
-		await fs.appendFile("./README.md", endOfReadmeNotice);
-	}
+	await fs.appendFile("./README.md", endOfReadmeNotice);
 
 	console.log(chalk.gray`✔️ Done.`);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #155
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

* Removes the redundant notice about being a template repo from the bottom of the README (it gets populated by the setup script)
* Switches single replacement strings to global replacement regexps in the setup script