### PR TITLE
chore: extend setup-test-e2e.js to check owner and repo title too

### DIFF
--- a/script/setup-test-e2e.js
+++ b/script/setup-test-e2e.js
@@ -19,3 +19,15 @@ const newPackageJson = JSON.parse(
 
 assert.equal(newPackageJson.description, description);
 assert.equal(newPackageJson.name, repository);
+
+for (const search of [
+	`/JoshuaKGoldberg/`,
+	"template-typescript-node-package",
+]) {
+	const grepResult =
+		await $`grep --exclude script/setup-test-e2e.js --exclude-dir node_modules -i ${search} *.* **/*.*`;
+	assert.equal(
+		grepResult.stdout.trim(),
+		`README.md:> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [template-typescript-node-package](https://github.com/JoshuaKGoldberg/template-typescript-node-package).`
+	);
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #157
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Also makes sure the old package info only exists in the little README.md disclaimer.