### PR TITLE
chore: add in discussion label

### DIFF
--- a/script/labels.json
+++ b/script/labels.json
@@ -40,6 +40,11 @@
 		"name": "status: duplicate"
 	},
 	{
+		"color": "#05104F",
+		"description": "Not yet ready for implementation or a pull request",
+		"name": "status: in discussion"
+	},
+	{
 		"color": "D3F82D",
 		"description": "Further research required...?",
 		"name": "status: needs investigation"


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #262
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

added the following code to labels.json:
```
	{
		"color": "#05104F",
		"description": "Not yet ready for implementation or a pull request",
		"name": "status: in discussion"
	},
```
