### PR TITLE
chore: Add --skip-uninstalls option to setup script

### DIFF
--- a/script/setup.js
+++ b/script/setup.js
@@ -502,6 +502,9 @@ try {
 	if (skipUninstalls) {
 		console.log();
 		console.log(chalk.gray`➖ Skipping removal of setup script.`);
+		console.log(
+			chalk.gray`➖ Skipping removal of devDependencies only used for setup.`
+		);
 	} else {
 		await withSpinner(
 			async () => {
@@ -515,19 +518,19 @@ try {
 				errorText: `Could not remove setup script. `,
 			}
 		);
-	}
 
-	await withSpinner(
-		async () => {
-			await $`pnpm remove execa @clack/prompts all-contributors-cli chalk octokit npm-user replace-in-file title-case -D`;
-		},
-		{
-			startText: `Removing devDependency packages only used for setup...`,
-			successText: `Removed devDependency packages only used for setup.`,
-			stopText: `Error removing devDependency packages only used for setup.`,
-			errorText: `Could not remove devDependency packages only used for setup. `,
-		}
-	);
+		await withSpinner(
+			async () => {
+				await $`pnpm remove execa @clack/prompts all-contributors-cli chalk octokit npm-user replace-in-file title-case -D`;
+			},
+			{
+				startText: `Removing devDependency packages only used for setup...`,
+				successText: `Removed devDependency packages only used for setup.`,
+				stopText: `Error removing devDependency packages only used for setup.`,
+				errorText: `Could not remove devDependency packages only used for setup. `,
+			}
+		);
+	}
 
 	prompts.outro(chalk.blue`Great, looks like everything worked! 🎉`);
 

--- a/script/setup.js
+++ b/script/setup.js
@@ -125,6 +125,7 @@ try {
 	);
 
 	const skipApi = values["skip-api"];
+	const skipUninstalls = values["skip-uninstalls"];
 
 	const successSpinnerBlock = (blockText) => {
 		s.start(chalk.green("✅ " + blockText));
@@ -498,18 +499,23 @@ try {
 		successSpinnerBlock(`Finished API hydration.`);
 	}
 
-	await withSpinner(
-		async () => {
-			await fs.rm("./script", { force: true, recursive: true });
-			await fs.rm(".github/workflows/setup.yml");
-		},
-		{
-			startText: `Removing setup script...`,
-			successText: `Removed setup script.`,
-			stopText: `Error removing setup script.`,
-			errorText: `Could not remove setup script. `,
-		}
-	);
+	if (skipUninstalls) {
+		console.log();
+		console.log(chalk.gray`➖ Skipping removal of setup script.`);
+	} else {
+		await withSpinner(
+			async () => {
+				await fs.rm("./script", { force: true, recursive: true });
+				await fs.rm(".github/workflows/setup.yml");
+			},
+			{
+				startText: `Removing setup script...`,
+				successText: `Removed setup script.`,
+				stopText: `Error removing setup script.`,
+				errorText: `Could not remove setup script. `,
+			}
+		);
+	}
 
 	await withSpinner(
 		async () => {

--- a/script/setup.js
+++ b/script/setup.js
@@ -133,8 +133,8 @@ try {
 	};
 
 	const skipSpinnerBlock = (blockText) => {
-		s.start(chalk.yellow("➖ " + blockText));
-		s.stop(chalk.yellow("➖ " + blockText));
+		s.start(chalk.gray("➖ " + blockText));
+		s.stop(chalk.gray("➖ " + blockText));
 	};
 
 	successSpinnerBlock("Started hydrating package metadata locally.");
@@ -500,9 +500,8 @@ try {
 	}
 
 	if (skipUninstalls) {
-		console.log();
-		console.log(
-			chalk.gray`➖ Skipping removal of devDependencies only used for setup.`
+		skipSpinnerBlock(
+			`Skipping uninstall of devDependencies only used for setup.`
 		);
 	} else {
 		await withSpinner(

--- a/script/setup.js
+++ b/script/setup.js
@@ -501,7 +501,6 @@ try {
 
 	if (skipUninstalls) {
 		console.log();
-		console.log(chalk.gray`➖ Skipping removal of setup script.`);
 		console.log(
 			chalk.gray`➖ Skipping removal of devDependencies only used for setup.`
 		);

--- a/script/setup.js
+++ b/script/setup.js
@@ -31,6 +31,7 @@ try {
 			repository: { type: "string" },
 			title: { type: "string" },
 			"skip-api": { type: "boolean" },
+			"skip-uninstalls": { type: "boolean" },
 		},
 		tokens: true,
 		strict: false,


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #352
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds ```--skip-uninstalls``` option, ```skipUninstalls``` constant, skips removal of ```/script``` and,  skips uninstallation of devDependencies only used in setup.
```
	if (skipUninstalls) {
		console.log();
		console.log(chalk.gray`➖ Skipping removal of setup script.`);
		console.log(
			chalk.gray`➖ Skipping removal of devDependencies only used for setup.`
		);
	} else {
		await withSpinner(
			async () => {
				await fs.rm("./script", { force: true, recursive: true });
				await fs.rm(".github/workflows/setup.yml");
			},
			{
				startText: `Removing setup script...`,
				successText: `Removed setup script.`,
				stopText: `Error removing setup script.`,
				errorText: `Could not remove setup script. `,
			}
		);

		await withSpinner(
			async () => {
				await $`pnpm remove execa @clack/prompts all-contributors-cli chalk octokit npm-user replace-in-file title-case -D`;
			},
			{
				startText: `Removing devDependency packages only used for setup...`,
				successText: `Removed devDependency packages only used for setup.`,
				stopText: `Error removing devDependency packages only used for setup.`,
				errorText: `Could not remove devDependency packages only used for setup. `,
			}
		);
	}
```
