### PR TITLE
chore: exclude lib/ in vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
 			// https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/100
 			provider: "istanbul",
 		},
+		exclude: ["lib", "node_modules"],
 	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #384
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

https://vitest.dev/config/#exclude