### PR TITLE
chore: enable jsdoc/check-tag-names, jsdoc/informative-docs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,9 @@ module.exports = {
 			files: ["**/*.ts"],
 			parser: "@typescript-eslint/parser",
 			rules: {
+				// These off-by-default rules work well for this repo and we like them on.
+				"jsdoc/informative-docs": "error",
+
 				// These on-by-default rules don't work well for this repo and we like them off.
 				"jsdoc/require-jsdoc": "off",
 				"jsdoc/require-param": "off",

--- a/src/greet.ts
+++ b/src/greet.ts
@@ -1,5 +1,9 @@
 import { GreetOptions } from "./types.js";
 
+/**
+ * @abstract
+ * @param {GreetOptions | string} options the options.
+ */
 export function greet(options: GreetOptions | string) {
 	const {
 		logger = console.log.bind(console),


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #371
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Enables the rule, with an intentional set of failures.