### PR TITLE
feat: add running user to all-contributors

### DIFF
--- a/script/setup-test-e2e.js
+++ b/script/setup-test-e2e.js
@@ -5,7 +5,7 @@ import { promises as fs } from "fs";
 import { globby } from "globby";
 
 const description = "New Description Test";
-const owner = "NewOwnerTest";
+const owner = "RNR1";
 const title = "New Title Test";
 const repository = "new-repository-test";
 

--- a/script/setup.js
+++ b/script/setup.js
@@ -167,11 +167,36 @@ try {
 		}
 	};
 
+	const mainContributions = [
+		"code",
+		"content",
+		"doc",
+		"ideas",
+		"infra",
+		"maintenance",
+		"projectManagement",
+		"tool",
+	];
+
+	const addContributor = (user, contributions = []) =>
+		$`all-contributors add ${user} ${contributions.join(",")}`;
+
 	await withSpinner(
 		async () => {
-			const user = JSON.parse((await $`gh api user`).stdout);
-			const userName = user.login;
-			await $`all-contributors add ${userName} code,content,doc,ideas,infra,maintenance,projectManagement,tool`;
+			let user;
+			try {
+				user = JSON.parse((await $`gh api user`).stdout).login;
+			} catch (err) {
+				console.warn(
+					chalk.gray(
+						"Couldn't authenticate GitHub user, falling back to the owner name you provided"
+					)
+				);
+				user = owner;
+			}
+
+			await addContributor(user, mainContributions);
+
 			const existingContributors = await readFileAsJSON(
 				"./.all-contributorsrc"
 			);
@@ -182,9 +207,7 @@ try {
 					JSON.stringify({
 						...existingContributors,
 						contributors: existingContributors.contributors
-							.filter(({ login }) =>
-								[userName, "JoshuaKGoldberg"].includes(login)
-							)
+							.filter(({ login }) => [user, "JoshuaKGoldberg"].includes(login))
 							.map((contributor) =>
 								contributor.login === "JoshuaKGoldberg"
 									? { ...contributor, contributions: ["tool"] }

--- a/script/setup.js
+++ b/script/setup.js
@@ -167,20 +167,6 @@ try {
 		}
 	};
 
-	const mainContributions = [
-		"code",
-		"content",
-		"doc",
-		"ideas",
-		"infra",
-		"maintenance",
-		"projectManagement",
-		"tool",
-	];
-
-	const addContributor = (user, contributions = []) =>
-		$`all-contributors add ${user} ${contributions.join(",")}`;
-
 	await withSpinner(
 		async () => {
 			let user;
@@ -189,13 +175,22 @@ try {
 			} catch (err) {
 				console.warn(
 					chalk.gray(
-						"Couldn't authenticate GitHub user, falling back to the owner name you provided"
+						`Couldn't authenticate GitHub user, falling back to the provided owner name '${owner}'`
 					)
 				);
 				user = owner;
 			}
 
-			await addContributor(user, mainContributions);
+			await $`all-contributors add ${user} ${[
+				"code",
+				"content",
+				"doc",
+				"ideas",
+				"infra",
+				"maintenance",
+				"projectManagement",
+				"tool",
+			].join(",")}`;
 
 			const existingContributors = await readFileAsJSON(
 				"./.all-contributorsrc"

--- a/script/setup.js
+++ b/script/setup.js
@@ -169,6 +169,9 @@ try {
 
 	await withSpinner(
 		async () => {
+			const user = JSON.parse((await $`gh api user`).stdout);
+			const userName = user.login;
+			await $`all-contributors add ${userName} code,content,doc,ideas,infra,maintenance,projectManagement,tool`;
 			const existingContributors = await readFileAsJSON(
 				"./.all-contributorsrc"
 			);
@@ -178,14 +181,15 @@ try {
 				prettier.format(
 					JSON.stringify({
 						...existingContributors,
-						contributors: [
-							{
-								...existingContributors.contributors.find(
-									({ login }) => login === "JoshuaKGoldberg"
-								),
-								contributions: ["tool"],
-							},
-						],
+						contributors: existingContributors.contributors
+							.filter(({ login }) =>
+								[userName, "JoshuaKGoldberg"].includes(login)
+							)
+							.map((contributor) =>
+								contributor.login === "JoshuaKGoldberg"
+									? { ...contributor, contributions: ["tool"] }
+									: contributor
+							),
 					}),
 					{ parser: "json" }
 				)


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to template-typescript-node-package! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #156
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I added some logic to add the running user to the `all-contributors` list (according to the authenticated GitHub CLI account).
At first, I tried only to use the owner variable that the user prompted, but it failed the tests, where a fabricated owner name was provided; if you prefer to only use the provided owner name without reaching out to gh CLI, we might need to adjust the tests a little bit.

