### PR TITLE
feat: offer to create or use a different repository in setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -112,6 +112,7 @@ module.exports = {
 		"simple-import-sort/imports": "error",
 
 		// These on-by-default rules don't work well for this repo and we like them off.
+		"no-constant-condition": "off",
 		"no-inner-declarations": "off",
 
 		// Stylistic concerns that don't interfere with Prettier

--- a/script/setup.js
+++ b/script/setup.js
@@ -646,8 +646,10 @@ try {
 	prompts.outro(
 		chalk.red`Looks like there was a problem. Correct it and try again? 😕`
 	);
+
 	console.log();
 	console.log(error);
+
 	if (skipRestore) {
 		console.log();
 		console.log(chalk.gray`Skipping restoring local repository, as requested.`);
@@ -657,7 +659,9 @@ try {
 			message:
 				"Do you want to restore the repository to how it was before running setup?",
 		});
+
 		handlePromptCancel(shouldRestore);
+
 		if (shouldRestore) {
 			console.log();
 			console.log(

--- a/script/setup.js
+++ b/script/setup.js
@@ -497,7 +497,7 @@ try {
 		}
 	);
 
-	if (octokit) {
+	if (!octokit) {
 		skipSpinnerBlock(`Skipping API hydration.`);
 	} else {
 		successSpinnerBlock(`Starting API hydration.`);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #183
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses a `while (true)` to continuously check if the `repository` exists. If it doesn't, the user can either:

* Bail out (`"bail"`)
* Create a new repository (`"create"`)
* Try again with a different repository (`"different"`)

Moves the `octokit` creation logic up in the file so that it can be used for repository checking. This is necessary because the `owner` might be private organization/user.