### PR TITLE
docs: added friendly explainer on top of ESLint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,13 @@
+/*
+👋 Hi! This ESLint configuration contains a lot more stuff than many repos'!
+You can read from it to see all sorts of linting goodness, but don't worry -
+it's not something you need to exhaustively understand immediately. 💙
+
+If you're interested in learning more, see the 'getting started' docs on:
+- ESLint: https://eslint.org
+- typescript-eslint: https://typescript-eslint.io
+*/
+
 /** @type {import("@types/eslint").Linter.Config} */
 module.exports = {
 	env: {

--- a/script/setup.js
+++ b/script/setup.js
@@ -363,7 +363,7 @@ try {
 				[/Template TypeScript Node Package/g, title],
 				[/JoshuaKGoldberg/g, owner],
 				[/template-typescript-node-package/g, repository],
-				[/\/\*\n.+\*\//gs, ``, "./eslintrc.cjs"],
+				[/\/\*\n.+\*\/\n\n/gs, ``, ".eslintrc.cjs"],
 				[/"setup": ".*",/g, ``, "./package.json"],
 				[/"setup:test": ".*",/g, ``, "./package.json"],
 				[/"author": ".+"/g, `"author": "${npmAuthor}"`, "./package.json"],

--- a/script/setup.js
+++ b/script/setup.js
@@ -363,6 +363,7 @@ try {
 				[/Template TypeScript Node Package/g, title],
 				[/JoshuaKGoldberg/g, owner],
 				[/template-typescript-node-package/g, repository],
+				[/\/\*\n.+\*\//gs, ``, "./eslintrc.cjs"],
 				[/"setup": ".*",/g, ``, "./package.json"],
 				[/"setup:test": ".*",/g, ``, "./package.json"],
 				[/"author": ".+"/g, `"author": "${npmAuthor}"`, "./package.json"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #413 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a nice and friendly notice on top of the ESLint config, with links to a couple of core docs.

Also removes that notice in the setup script - I figure consuming repos likely don't want my notices.