### PR TITLE
feat: delete unnecessary labels on setup

### DIFF
--- a/script/setup.js
+++ b/script/setup.js
@@ -506,19 +506,29 @@ try {
 
 		await withSpinner(
 			async () => {
+				const getLabelName = (label) => label.name;
+
 				const existingLabels = JSON.parse(
 					(await $`gh label list --json name`).stdout || "[]"
-				);
+				).map(getLabelName);
 
 				const outcomeLabels = await readFileAsJSON("./script/labels.json");
 
 				for (const outcome of outcomeLabels) {
 					const action = existingLabels.some(
-						(existing) => existing.name === outcome.name
+						(existing) => existing === outcome.name
 					)
 						? "edit"
 						: "create";
 					await $`gh label ${action} ${outcome.name} --color ${outcome.color} --description ${outcome.description}`;
+				}
+
+				const allowedLabels = new Set(outcomeLabels.map(getLabelName));
+
+				for (const existingLabel of existingLabels) {
+					if (!allowedLabels.has(existingLabel)) {
+						await $`gh label delete ${existingLabel} --yes`;
+					}
 				}
 			},
 			{


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #331
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

After hydrating allowed labels, any remaining (not allowed) existing label is deleted with [`gh label delete`](https://cli.github.com/manual/gh_label_delete).