### PR TITLE
feat: improve complaint when gh auth status fails

### DIFF
--- a/script/setup.js
+++ b/script/setup.js
@@ -92,7 +92,15 @@ try {
 
 		await withSpinner(
 			async () => {
-				await $`gh auth status`;
+				try {
+					await $`gh auth status`;
+				} catch (error) {
+					console.error();
+					console.error(chalk.red(error.message));
+					console.error();
+					process.exit(0);
+				}
+
 				const auth = (await $`gh auth token`).stdout.trim();
 
 				octokit = new Octokit({ auth });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #400
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses a `try`/`catch` with a manual `console.error`. Because this is really part of the script setup, directly calls `process.exit(0)` instead of throwing an error through the normal handling.