### PR TITLE
fix: manually call post-release.yml on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,12 @@ jobs:
               }
             }
       - env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: if pnpm run should-semantic-release ; then pnpm release-it --verbose ; fi
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          if pnpm run should-semantic-release ; then
+            pnpm release-it --verbose
+            gh workflow run post-release.yml
+          fi
       - if: always()
         name: Recreate branch protection on main
         uses: actions/github-script@v6.4.1

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,8 +7,5 @@
 		"autoGenerate": true,
 		"release": true,
 		"releaseName": "v${version}"
-	},
-	"hooks": {
-		"before:bump": "if ! pnpm run should-semantic-release --verbose ; then exit 1 ; fi"
 	}
 }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To use this template:
 1. Click the [_Use this template_](https://github.com/JoshuaKGoldberg/template-typescript-node-package/generate) button to create a new repository with the same Git history
 2. Open that repository, such as by [cloning it locally](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) or [developing in a codespace](https://docs.github.com/en/codespaces/developing-in-codespaces/developing-in-a-codespace)
 3. Create two tokens in [repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
-   - `ACCESS_TOKEN`: A [GitHub PAT](https://github.com/settings/tokens/new) with _repo_ permissions
+   - `ACCESS_TOKEN`: A [GitHub PAT](https://github.com/settings/tokens/new) with _repo_ and _workflow_ permissions
    - `NPM_TOKEN`: An [npm access token](https://docs.npmjs.com/creating-and-viewing-access-tokens/) with _Automation_ permissions
 4. `pnpm install`
 5. `pnpm run setup` to run the setup script


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #390
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/390#issuecomment-1543335037, the workflow needs to be manually fired.

Also removes an old unnecessary `hooks:bump` line from `.release-it.json` that I don't think ever did anything.