### PR TITLE
fix: use npm pkg version in post-release

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,6 +3,7 @@ jobs:
     name: Comment on relevant PRs and issues
     runs-on: ubuntu-latest
     steps:
+      - run: echo "version=$(npm pkg get version)" >> "$GITHUB_ENV"
       - uses: apexskier/github-release-commenter@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -11,8 +12,8 @@ jobs:
 
             The release is available on:
 
-            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/template-typescript-node-package/v/{release_tag})
-            * [GitHub release](https://github.com/JoshuaKGoldberg/template-typescript-node-package/releases/tag/v{release_tag})
+            * [GitHub releases]({release_link})
+            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/template-typescript-node-package/v/${{ env.version }}})
 
             Cheers! 📦🚀
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,7 +3,7 @@ jobs:
     name: Comment on relevant PRs and issues
     runs-on: ubuntu-latest
     steps:
-      - run: echo "version=$(npm pkg get version)" >> "$GITHUB_ENV"
+      - run: echo "npm_version=$(npm pkg get version)" >> "$GITHUB_ENV"
       - uses: apexskier/github-release-commenter@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -13,7 +13,7 @@ jobs:
             The release is available on:
 
             * [GitHub releases]({release_link})
-            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/template-typescript-node-package/v/${{ env.version }}})
+            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/template-typescript-node-package/v/${{ env.npm_version }}})
 
             Cheers! 📦🚀
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #427
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses `npm pkg get version` to set the npm version in an `npm_version` env variable per https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable. Then uses it in the comment template.