### PR TITLE
fix: fix post-release.yml comment-template links

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -7,7 +7,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/prepare
-      - run: echo "npm_version=$(npm pkg get version)" >> "$GITHUB_ENV"
       - uses: apexskier/github-release-commenter@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,6 +3,10 @@ jobs:
     name: Comment on relevant PRs and issues
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/prepare
       - run: echo "npm_version=$(npm pkg get version)" >> "$GITHUB_ENV"
       - uses: apexskier/github-release-commenter@v1
         with:
@@ -12,7 +16,7 @@ jobs:
 
             The release is available on:
 
-            * [GitHub releases]({release_link})
+            * [GitHub releases](https://github.com/JoshuaKGoldberg/template-typescript-node-package/releases/tag/{release_tag})
             * [npm package (@latest dist-tag)](https://www.npmjs.com/package/template-typescript-node-package/v/${{ env.npm_version }}})
 
             Cheers! 📦🚀

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -6,7 +6,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/prepare
+      - run: echo "npm_version=$(npm pkg get version)" >> "$GITHUB_ENV"
       - uses: apexskier/github-release-commenter@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #432
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

* `package.json` wasn't being found because the repo wasn't checked out yet
* `release_link` is a full Markdown link, not the direct URL