### PR TITLE
fix: respect existing package.json contents in hydration

### DIFF
--- a/src/hydrate/steps/clearUnnecessaryFiles.ts
+++ b/src/hydrate/steps/clearUnnecessaryFiles.ts
@@ -3,7 +3,9 @@ import { execaCommand } from "execa";
 export async function clearUnnecessaryFiles() {
 	for (const glob of [
 		"dist lib package-lock.json yarn.lock",
-		".eslintrc*",
+		".eslint*",
+		".prettier*",
+		"jest.*",
 		"./src/**/*.js",
 	]) {
 		try {

--- a/src/hydrate/steps/clearUnnecessaryFiles.ts
+++ b/src/hydrate/steps/clearUnnecessaryFiles.ts
@@ -3,9 +3,7 @@ import { execaCommand } from "execa";
 export async function clearUnnecessaryFiles() {
 	for (const glob of [
 		"dist lib package-lock.json yarn.lock",
-		".eslint*",
-		".prettier*",
-		"jest.*",
+		".eslintrc*",
 		"./src/**/*.js",
 	]) {
 		try {

--- a/src/hydrate/steps/writing/creation/index.ts
+++ b/src/hydrate/steps/writing/creation/index.ts
@@ -5,11 +5,13 @@ import { createDotHusky } from "./dotHusky.js";
 import { createDotVSCode } from "./dotVSCode.js";
 import { createRootFiles } from "./rootFiles.js";
 
-export function createStructure(values: HydrationInputValues): Structure {
+export async function createStructure(
+	values: HydrationInputValues
+): Promise<Structure> {
 	return {
 		".github": createDotGitHub(values),
 		".husky": createDotHusky(),
 		".vscode": createDotVSCode(),
-		...createRootFiles(values),
+		...(await createRootFiles(values)),
 	};
 }

--- a/src/hydrate/steps/writing/creation/writePackageJson.test.ts
+++ b/src/hydrate/steps/writing/creation/writePackageJson.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { writePackageJson } from "./writePackageJson.js";
 
-const mockreadFileAsJson = vi.fn();
+const mockReadFileAsJson = vi.fn();
 
 vi.mock("../../../../shared/readFileAsJson.js", () => ({
 	get readFileAsJson() {
-		return mockreadFileAsJson;
+		return mockReadFileAsJson;
 	},
 }));
 
@@ -23,7 +23,7 @@ const values = {
 describe("writePackageJson", () => {
 	it("preserves existing dependencies when they exist", async () => {
 		const dependencies = { abc: "1.2.3" };
-		mockreadFileAsJson.mockResolvedValue({ dependencies });
+		mockReadFileAsJson.mockResolvedValue({ dependencies });
 
 		const packageJson = await writePackageJson(values);
 
@@ -33,7 +33,7 @@ describe("writePackageJson", () => {
 	});
 
 	it("includes a release script when releases is true", async () => {
-		mockreadFileAsJson.mockResolvedValue({});
+		mockReadFileAsJson.mockResolvedValue({});
 
 		const packageJson = await writePackageJson({
 			...values,
@@ -50,7 +50,7 @@ describe("writePackageJson", () => {
 	});
 
 	it("includes a test script when unitTests is true", async () => {
-		mockreadFileAsJson.mockResolvedValue({});
+		mockReadFileAsJson.mockResolvedValue({});
 
 		const packageJson = await writePackageJson({
 			...values,

--- a/src/hydrate/steps/writing/creation/writePackageJson.test.ts
+++ b/src/hydrate/steps/writing/creation/writePackageJson.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { writePackageJson } from "./writePackageJson.js";
+
+const mockreadFileAsJson = vi.fn();
+
+vi.mock("../../../../shared/readFileAsJson.js", () => ({
+	get readFileAsJson() {
+		return mockreadFileAsJson;
+	},
+}));
+
+const values = {
+	author: "test-author",
+	description: "test-description",
+	email: "test-email",
+	owner: "test-owner",
+	releases: false,
+	repository: "test-repository",
+	unitTests: false,
+};
+
+describe("writePackageJson", () => {
+	it("preserves existing dependencies when they exist", async () => {
+		const dependencies = { abc: "1.2.3" };
+		mockreadFileAsJson.mockResolvedValue({ dependencies });
+
+		const packageJson = await writePackageJson(values);
+
+		expect(JSON.parse(packageJson)).toEqual(
+			expect.objectContaining({ dependencies })
+		);
+	});
+
+	it("includes a release script when releases is true", async () => {
+		mockreadFileAsJson.mockResolvedValue({});
+
+		const packageJson = await writePackageJson({
+			...values,
+			releases: true,
+		});
+
+		expect(JSON.parse(packageJson)).toEqual(
+			expect.objectContaining({
+				scripts: expect.objectContaining({
+					"should-semantic-release": "should-semantic-release --verbose",
+				}),
+			})
+		);
+	});
+
+	it("includes a test script when unitTests is true", async () => {
+		mockreadFileAsJson.mockResolvedValue({});
+
+		const packageJson = await writePackageJson({
+			...values,
+			unitTests: true,
+		});
+
+		expect(JSON.parse(packageJson)).toEqual(
+			expect.objectContaining({
+				scripts: expect.objectContaining({
+					test: "vitest",
+				}),
+			})
+		);
+	});
+});

--- a/src/hydrate/steps/writing/creation/writePackageJson.ts
+++ b/src/hydrate/steps/writing/creation/writePackageJson.ts
@@ -30,7 +30,7 @@ export async function writePackageJson({
 		prettierConfig: undefined,
 		types: undefined,
 
-		// The rest of the fields are ones we know from templating
+		// The rest of the fields are ones we know from our template
 		name: repository,
 		description,
 		repository: {

--- a/src/hydrate/steps/writing/creation/writePackageJson.ts
+++ b/src/hydrate/steps/writing/creation/writePackageJson.ts
@@ -1,0 +1,73 @@
+import { readFileAsJson } from "../../../../shared/readFileAsJson.js";
+import { HydrationInputValues } from "../../../values/types.js";
+import { formatJson } from "./formatters/formatJson.js";
+
+export async function writePackageJson({
+	author,
+	description,
+	email,
+	owner,
+	releases,
+	repository,
+	unitTests,
+}: Pick<
+	HydrationInputValues,
+	| "author"
+	| "description"
+	| "email"
+	| "owner"
+	| "releases"
+	| "repository"
+	| "unitTests"
+>) {
+	return formatJson({
+		// To start, copy over all existing package fields (e.g. "dependencies")
+		...((await readFileAsJson("./package.json")) as object),
+
+		// Remove fields we know we don't want, such as old or redundant configs
+		eslintConfig: undefined,
+		husky: undefined,
+		prettierConfig: undefined,
+		types: undefined,
+
+		// The rest of the fields are ones we know from templating
+		name: repository,
+		description,
+		repository: {
+			type: "git",
+			url: `https://github.com/${owner}/${repository}`,
+		},
+		license: "MIT",
+		author: { email, name: author },
+		type: "module",
+		main: "./lib/index.js",
+		files: ["lib/", "package.json", "LICENSE.md", "README.md"],
+		scripts: {
+			build: "tsc",
+			format: 'prettier "**/*" --ignore-unknown',
+			"format:write": "pnpm format --write",
+			lint: "eslint . --max-warnings 0 --report-unused-disable-directives",
+			"lint:knip": "knip",
+			"lint:md":
+				'markdownlint "**/*.md" ".github/**/*.md" --rules sentences-per-line',
+			"lint:package": "npmPkgJsonLint .",
+			"lint:packages": "pnpm dedupe --check",
+			"lint:spelling": 'cspell "**" ".github/**/*"',
+			prepare: "husky install",
+			...(releases && {
+				"should-semantic-release": "should-semantic-release --verbose",
+			}),
+			...(unitTests && { test: "vitest" }),
+		},
+		"lint-staged": {
+			"*": "prettier --ignore-unknown --write",
+		},
+		packageManager: "pnpm@8.5.0",
+		engines: {
+			node: ">=18",
+		},
+		publishConfig: {
+			provenance: true,
+		},
+	});
+}

--- a/src/hydrate/steps/writing/writeStructure.ts
+++ b/src/hydrate/steps/writing/writeStructure.ts
@@ -3,5 +3,5 @@ import { createStructure } from "./creation/index.js";
 import { writeStructureWorker } from "./writeStructureWorker.js";
 
 export async function writeStructure(values: HydrationInputValues) {
-	return await writeStructureWorker(createStructure(values), ".");
+	return await writeStructureWorker(await createStructure(values), ".");
 }

--- a/src/setup/settings/addOwnerAsAllContributor.ts
+++ b/src/setup/settings/addOwnerAsAllContributor.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 import { $ } from "execa";
 import prettier from "prettier";
 
-import { readFileAsJSON } from "../readFileAsJSON.js";
+import { readFileAsJson } from "../../shared/readFileAsJson.js";
 
 interface GhUserOutput {
 	login: string;
@@ -34,7 +34,7 @@ export async function addOwnerAsAllContributor(owner: string) {
 		"tool",
 	].join(",")}`;
 
-	const existingContributors = (await readFileAsJSON(
+	const existingContributors = (await readFileAsJson(
 		"./.all-contributorsrc"
 	)) as AllContributorsData;
 	if (!isValidAllContributorsData(existingContributors)) {

--- a/src/setup/steps/labels/hydrateRepositoryLabels.ts
+++ b/src/setup/steps/labels/hydrateRepositoryLabels.ts
@@ -1,6 +1,6 @@
 import { $ } from "execa";
 
-import { readFileAsJSON } from "../../readFileAsJSON.js";
+import { readFileAsJson } from "../../../shared/readFileAsJson.js";
 import { getExistingEquivalentLabel } from "./getExistingEquivalentLabel.js";
 
 interface GhLabelData {
@@ -22,7 +22,7 @@ export async function hydrateRepositoryLabels() {
 		) as GhLabelData[]
 	).map(getLabelName);
 
-	const outcomeLabels = (await readFileAsJSON(
+	const outcomeLabels = (await readFileAsJson(
 		"./src/setup/labels.json"
 	)) as FileLabelData[];
 

--- a/src/setup/steps/updateLocalFiles.ts
+++ b/src/setup/steps/updateLocalFiles.ts
@@ -1,6 +1,6 @@
 import replaceInFile from "replace-in-file";
 
-import { readFileAsJSON } from "../readFileAsJSON.js";
+import { readFileAsJson } from "../../shared/readFileAsJson.js";
 
 interface UpdateLocalFilesOptions {
 	description: string;
@@ -22,7 +22,7 @@ export async function updateLocalFiles({
 	repository,
 	title,
 }: UpdateLocalFilesOptions) {
-	const existingPackage = (await readFileAsJSON(
+	const existingPackage = (await readFileAsJson(
 		"./package.json"
 	)) as ExistingPackageData;
 

--- a/src/shared/readFileAsJson.test.ts
+++ b/src/shared/readFileAsJson.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { readFileAsJson } from "./readFileAsJson.js";
+
+const mockReadFile = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+	get readFile() {
+		return mockReadFile;
+	},
+}));
+
+describe("readFileAsJson", () => {
+	it("returns the file's parsed contents when it exists", async () => {
+		const data = { abc: 123 };
+
+		mockReadFile.mockResolvedValue(JSON.stringify(data));
+
+		const actual = await readFileAsJson("filePath.json");
+
+		expect(actual).toEqual(data);
+	});
+
+	it("throws an error when the file doesn't exist", async () => {
+		const error = new Error("Oh no!");
+
+		mockReadFile.mockRejectedValue(error);
+
+		await expect(() => readFileAsJson("filePath.json")).rejects.toEqual(
+			new Error(
+				`Could not read file from filePath.json as JSON. Please ensure the file exists and is valid JSON.`,
+				{ cause: error }
+			)
+		);
+	});
+});

--- a/src/shared/readFileAsJson.ts
+++ b/src/shared/readFileAsJson.ts
@@ -1,6 +1,6 @@
-import { promises as fs } from "fs";
+import * as fs from "node:fs/promises";
 
-export async function readFileAsJSON(filePath: string) {
+export async function readFileAsJson(filePath: string) {
 	try {
 		return JSON.parse((await fs.readFile(filePath)).toString()) as unknown;
 	} catch (error) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #503
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Splits the creation of new `package.json` contents into a new `writePackageJson` file. It reads the existing `package.json` as JSON and uses all previously existing fields by default.

Note that this PR also standardizes from `JSON` to `Json` in file names.