### PR TITLE
fix: ignore all root coverage directories in spelling

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,9 +1,9 @@
 {
 	"dictionaries": ["typescript"],
 	"ignorePaths": [
+		"./coverage*",
 		".github",
 		"CHANGELOG.md",
-		"coverage",
 		"lib",
 		"node_modules",
 		"pnpm-lock.yaml",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #510
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches to a relative path so that it doesn't detect paths like `src/coverage` by accident, if they happen to exist.