### PR TITLE
feat: run ESLint and Prettier fixers in hydration

### DIFF
--- a/src/hydrate/hydrate.ts
+++ b/src/hydrate/hydrate.ts
@@ -9,6 +9,7 @@ import {
 import { runOrRestore } from "../shared/runOrRestore.js";
 import { clearUnnecessaryFiles } from "./steps/clearUnnecessaryFiles.js";
 import { finalizeDependencies as finalizeDependencies } from "./steps/finalizeDependencies.js";
+import { runCommand } from "./steps/runCommand.js";
 import { writeReadme } from "./steps/writeReadme.js";
 import { writeStructure } from "./steps/writing/writeStructure.js";
 import { getHydrationDefaults } from "./values/getHydrationDefaults.js";
@@ -52,6 +53,9 @@ export async function hydrate(args: string[]) {
 					"finalizing dependencies"
 				);
 			}
+
+			await runCommand("pnpm lint --fix", "auto-fixing lint rules");
+			await runCommand("pnpm format --write", "formatting files");
 
 			if (hydrationSkips["skip-setup"]) {
 				skipSpinnerBlock(`Done hydrating, and skipping setup command.`);

--- a/src/hydrate/steps/runCommand.test.ts
+++ b/src/hydrate/steps/runCommand.test.ts
@@ -1,0 +1,48 @@
+import chalk from "chalk";
+import { describe, expect, it, vi } from "vitest";
+
+import { runCommand } from "./runCommand.js";
+
+const mockExecaCommand = vi.fn().mockRejectedValue("Oh no!");
+
+vi.mock("execa", () => ({
+	get execaCommand() {
+		return mockExecaCommand;
+	},
+}));
+
+const mockLogLine = vi.fn();
+
+vi.mock("../../shared/cli/lines.js", () => ({
+	get logLine() {
+		return mockLogLine;
+	},
+}));
+
+vi.mock("../../shared/cli/spinners.js", () => ({
+	withSpinner: vi.fn((callback: () => unknown) => callback()),
+}));
+
+describe("runCommand", () => {
+	it("does not log when the command succeeds", async () => {
+		mockExecaCommand.mockResolvedValue(undefined);
+
+		await runCommand("command", "label");
+
+		expect(mockLogLine).not.toHaveBeenCalled();
+	});
+
+	it("logs when the command failures", async () => {
+		mockExecaCommand.mockRejectedValue(new Error("Oh no!"));
+
+		await runCommand("command", "label");
+
+		expect(mockLogLine).toHaveBeenCalledWith(
+			[
+				chalk.yellow(`⚠️ Running \``),
+				chalk.yellowBright("command"),
+				chalk.yellow(`\` failed. You should run it and fix its complaints.`),
+			].join("")
+		);
+	});
+});

--- a/src/hydrate/steps/runCommand.ts
+++ b/src/hydrate/steps/runCommand.ts
@@ -1,0 +1,27 @@
+import chalk from "chalk";
+import { execaCommand } from "execa";
+
+import { logLine } from "../../shared/cli/lines.js";
+import { withSpinner } from "../../shared/cli/spinners.js";
+
+export async function runCommand(command: string, label: string) {
+	const succeeded = await withSpinner(async () => {
+		try {
+			await execaCommand(command);
+			return true;
+		} catch {
+			return false;
+		}
+	}, label);
+
+	if (!succeeded) {
+		logLine();
+		logLine(
+			[
+				chalk.yellow(`⚠️ Running \``),
+				chalk.yellowBright(command),
+				chalk.yellow(`\` failed. You should run it and fix its complaints.`),
+			].join("")
+		);
+	}
+}

--- a/src/shared/cli/spinners.ts
+++ b/src/shared/cli/spinners.ts
@@ -13,6 +13,11 @@ export function successSpinnerBlock(blockText: string) {
 	s.stop(chalk.green("✅ " + blockText));
 }
 
+export function warnSpinnerBlock(blockText: string) {
+	s.start(chalk.yellow("⚠️ " + blockText));
+	s.stop(chalk.yellow("⚠️ " + blockText));
+}
+
 export async function withSpinner<Return>(
 	callback: () => Promise<Return>,
 	label: string,
@@ -27,7 +32,7 @@ export async function withSpinner<Return>(
 			const extra = warningHint ? `: ${warningHint}` : "";
 			s.stop(chalk.yellow(`⚠️ Error ${label}${extra}.`));
 		} else {
-			s.stop(chalk.green(`✅ Success ${label}.`));
+			s.stop(chalk.green(`✅ Passed ${label}.`));
 		}
 
 		return result;

--- a/src/shared/cli/spinners.ts
+++ b/src/shared/cli/spinners.ts
@@ -13,11 +13,6 @@ export function successSpinnerBlock(blockText: string) {
 	s.stop(chalk.green("✅ " + blockText));
 }
 
-export function warnSpinnerBlock(blockText: string) {
-	s.start(chalk.yellow("⚠️ " + blockText));
-	s.stop(chalk.yellow("⚠️ " + blockText));
-}
-
 export async function withSpinner<Return>(
 	callback: () => Promise<Return>,
 	label: string,

--- a/src/shared/defaults.ts
+++ b/src/shared/defaults.ts
@@ -1,6 +1,8 @@
 import chalk from "chalk";
 import { $ } from "execa";
 
+import { logLine } from "./cli/lines.js";
+
 export async function getDefaultSettings() {
 	let gitRemoteFetch;
 	try {
@@ -9,7 +11,8 @@ export async function getDefaultSettings() {
 			.pipeStdout?.($({ stdin: "pipe" })`grep origin`)
 			.pipeStdout?.($({ stdin: "pipe" })`grep fetch`);
 	} catch {
-		console.log(
+		logLine();
+		logLine(
 			chalk.gray(
 				"Could not populate default owner and repository. Did not detect a Git repository with an origin. "
 			)


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #452
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per the issue, runs `pnpm lint --fix` near the end of hydration. Also runs `pnpm format --write`. For both, if there was an error, the user is warned to run the command themselves.

Rewords from _"Succeeded"_ to _"Passed"_ for spinner blocks to indicate that there might not have been a total success.