### PR TITLE
fix: match existing, prefixed labels in setup

### DIFF
--- a/src/setup/settings/addOwnerAsAllContributor.ts
+++ b/src/setup/settings/addOwnerAsAllContributor.ts
@@ -22,7 +22,7 @@ export async function addOwnerAsAllContributor(owner: string) {
 		user = owner;
 	}
 
-	await $`npx -y all-contributors-cli add ${user} ${[
+	await $`npx -y all-contributors-cli@6.25 add ${user} ${[
 		"code",
 		"content",
 		"doc",

--- a/src/setup/steps/labels/getExistingEquivalentLabel.test.ts
+++ b/src/setup/steps/labels/getExistingEquivalentLabel.test.ts
@@ -15,10 +15,16 @@ describe("getExistingEquivalentLabel", () => {
 		expect(actual).toBe(undefined);
 	});
 
-	it("returns the existing label when it matches by name", () => {
+	it("returns an existing un-prefixed label when it matches by name", () => {
 		const actual = getExistingEquivalentLabel(["def", "abc", "ghi"], "abc");
 
 		expect(actual).toBe("abc");
+	});
+
+	it("returns an existing prefixed label when it matches by name", () => {
+		const actual = getExistingEquivalentLabel(["abc: def"], "abc: def");
+
+		expect(actual).toBe("abc: def");
 	});
 
 	it("returns the existing label when it matches excluding prefix", () => {

--- a/src/setup/steps/labels/getExistingEquivalentLabel.ts
+++ b/src/setup/steps/labels/getExistingEquivalentLabel.ts
@@ -9,8 +9,11 @@ export function getExistingEquivalentLabel(
 ) {
 	const outcomeTrimmed = outcomeLabel.replace(/\w+: (\w+)/, "$1");
 
-	return existingLabels.find(
-		(existingLabel) =>
-			aliases.has(existingLabel) || existingLabel === outcomeTrimmed
-	);
+	return existingLabels.find((existingLabel) => {
+		return (
+			existingLabel === outcomeLabel ||
+			existingLabel === outcomeTrimmed ||
+			aliases.get(existingLabel) === outcomeLabel
+		);
+	});
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #529
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes the `.find` logic to match on an aliased or prefixed label.