### PR TITLE
fix: specify squash merge defaults in repo setup

### DIFF
--- a/src/setup/steps/hydrateRepositorySettings.ts
+++ b/src/setup/steps/hydrateRepositorySettings.ts
@@ -21,5 +21,7 @@ export async function hydrateRepositorySettings(
 		has_wiki: false,
 		owner,
 		repo: repository,
+		squash_merge_commit_message: "PR_BODY",
+		squash_merge_commit_title: "PR_TITLE",
 	});
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #531
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the two settings for the GitHub API per https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository.