### PR TITLE
fix: only run post-release once

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -25,4 +25,3 @@ on:
   release:
     types:
       - published
-  workflow_dispatch: ~

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           if pnpm run should-semantic-release ; then
             pnpm release-it --verbose
-            gh workflow run post-release.yml
           fi
       - if: always()
         name: Recreate branch protection on main


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #433
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the manual dispatch of `post-release.yml`, so that `release.types` > `- published` is how it's triggered.

Co-authored-by: Navin Moorthy <navin007.a@gmail.com>