### PR TITLE
fix: lint .eslintrc.cjs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
 		"plugin:regexp/recommended",
 		"prettier",
 	],
+	/* eslint-disable perfectionist/sort-objects -- https://github.com/azat-io/eslint-plugin-perfectionist/issues/22 */
 	overrides: [
 		{
 			extends: ["plugin:markdown/recommended"],
@@ -46,11 +47,11 @@ module.exports = {
 			},
 		},
 		{
+			excludedFiles: ["**/*.md/*.ts"],
 			extends: [
 				"plugin:@typescript-eslint/recommended-requiring-type-checking",
 				"plugin:@typescript-eslint/strict",
 			],
-			excludedFiles: ["**/*.md/*.ts"],
 			files: ["**/*.ts"],
 			parser: "@typescript-eslint/parser",
 			parserOptions: {
@@ -70,13 +71,13 @@ module.exports = {
 			},
 		},
 		{
-			files: ["*.json", "*.jsonc"],
 			excludedFiles: ["package.json"],
+			extends: ["plugin:jsonc/recommended-with-json"],
+			files: ["*.json", "*.jsonc"],
 			parser: "jsonc-eslint-parser",
 			rules: {
 				"jsonc/sort-keys": "error",
 			},
-			extends: ["plugin:jsonc/recommended-with-json"],
 		},
 		{
 			files: "**/*.test.ts",
@@ -109,6 +110,7 @@ module.exports = {
 			},
 		},
 	],
+	/* eslint-enable perfectionist/sort-objects */
 	parser: "@typescript-eslint/parser",
 	plugins: [
 		"@typescript-eslint",
@@ -124,19 +126,19 @@ module.exports = {
 	rules: {
 		// These off/less-strict-by-default rules work well for this repo and we like them on.
 		"@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "all" }],
-		"import/extensions": ["error", "ignorePackages"],
-		"no-only-tests/no-only-tests": "error",
-
-		// These on-by-default rules don't work well for this repo and we like them off.
-		"no-constant-condition": "off",
-		"no-case-declarations": "off",
-		"no-inner-declarations": "off",
-
-		// Stylistic concerns that don't interfere with Prettier
-		"padding-line-between-statements": "off",
 		"@typescript-eslint/padding-line-between-statements": [
 			"error",
 			{ blankLine: "always", next: "*", prev: "block-like" },
 		],
+		"import/extensions": ["error", "ignorePackages"],
+
+		// These on-by-default rules don't work well for this repo and we like them off.
+		"no-case-declarations": "off",
+		"no-constant-condition": "off",
+		"no-inner-declarations": "off",
+
+		"no-only-tests/no-only-tests": "error",
+		// Stylistic concerns that don't interfere with Prettier
+		"padding-line-between-statements": "off",
 	},
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -110,7 +110,6 @@ module.exports = {
 			},
 		},
 	],
-	/* eslint-enable perfectionist/sort-objects */
 	parser: "@typescript-eslint/parser",
 	plugins: [
 		"@typescript-eslint",
@@ -125,11 +124,8 @@ module.exports = {
 	root: true,
 	rules: {
 		// These off/less-strict-by-default rules work well for this repo and we like them on.
+		"no-only-tests/no-only-tests": "error",
 		"@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "all" }],
-		"@typescript-eslint/padding-line-between-statements": [
-			"error",
-			{ blankLine: "always", next: "*", prev: "block-like" },
-		],
 		"import/extensions": ["error", "ignorePackages"],
 
 		// These on-by-default rules don't work well for this repo and we like them off.
@@ -137,8 +133,12 @@ module.exports = {
 		"no-constant-condition": "off",
 		"no-inner-declarations": "off",
 
-		"no-only-tests/no-only-tests": "error",
 		// Stylistic concerns that don't interfere with Prettier
 		"padding-line-between-statements": "off",
+		"@typescript-eslint/padding-line-between-statements": [
+			"error",
+			{ blankLine: "always", next: "*", prev: "block-like" },
+		],
 	},
+	/* eslint-enable perfectionist/sort-objects */
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -124,9 +124,9 @@ module.exports = {
 	root: true,
 	rules: {
 		// These off/less-strict-by-default rules work well for this repo and we like them on.
-		"no-only-tests/no-only-tests": "error",
 		"@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "all" }],
 		"import/extensions": ["error", "ignorePackages"],
+		"no-only-tests/no-only-tests": "error",
 
 		// These on-by-default rules don't work well for this repo and we like them off.
 		"no-case-declarations": "off",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"format": "prettier \"**/*\" --ignore-unknown",
 		"format:write": "pnpm format --write",
 		"hydrate:test": "node script/hydrate-test-e2e.js",
-		"lint": "eslint . --max-warnings 0 --report-unused-disable-directives",
+		"lint": "eslint . .*js --max-warnings 0 --report-unused-disable-directives",
 		"lint:knip": "knip",
 		"lint:md": "markdownlint \"**/*.md\" \".github/**/*.md\" --rules sentences-per-line",
 		"lint:package": "npmPkgJsonLint .",

--- a/sample.js
+++ b/sample.js
@@ -1,7 +1,0 @@
-export default {
-	// This should come first
-	def: true,
-
-	// This should come second
-	abc: true,
-};

--- a/sample.js
+++ b/sample.js
@@ -1,0 +1,7 @@
+export default {
+	// This should come first
+	def: true,
+
+	// This should come second
+	abc: true,
+};

--- a/src/hydrate/steps/writing/creation/rootFiles.ts
+++ b/src/hydrate/steps/writing/creation/rootFiles.ts
@@ -50,6 +50,7 @@ module.exports = {
 		"plugin:regexp/recommended",
 		"prettier",
 	],
+	/* eslint-disable perfectionist/sort-objects -- https://github.com/azat-io/eslint-plugin-perfectionist/issues/22 */
 	overrides: [
 		{
 			extends: ["plugin:markdown/recommended"],
@@ -75,11 +76,11 @@ module.exports = {
 			},
 		},
 		{
+			excludedFiles: ["**/*.md/*.ts"],
 			extends: [
 				"plugin:@typescript-eslint/recommended-requiring-type-checking",
 				"plugin:@typescript-eslint/strict",
 			],
-			excludedFiles: ["**/*.md/*.ts"],
 			files: ["**/*.ts"],
 			parser: "@typescript-eslint/parser",
 			parserOptions: {
@@ -91,13 +92,13 @@ module.exports = {
 			},
 		},
 		{
-			files: ["*.json", "*.jsonc"],
 			excludedFiles: ["package.json"],
+			extends: ["plugin:jsonc/recommended-with-json"],
+			files: ["*.json", "*.jsonc"],
 			parser: "jsonc-eslint-parser",
 			rules: {
 				"jsonc/sort-keys": "error",
 			},
-			extends: ["plugin:jsonc/recommended-with-json"],
 		},${
 			values.unitTests
 				? `\n{
@@ -152,6 +153,7 @@ module.exports = {
 		}
 
 		// These on-by-default rules don't work well for this repo and we like them off.
+		"no-case-declarations": "off",
 		"no-constant-condition": "off",
 		"no-inner-declarations": "off",
 
@@ -163,6 +165,7 @@ module.exports = {
 			{ blankLine: "always", next: "*", prev: "block-like" },
 		],
 	},
+	/* eslint-enable perfectionist/sort-objects */
 };
 `,
 		".gitignore": formatIgnoreFile([

--- a/src/hydrate/steps/writing/creation/writePackageJson.ts
+++ b/src/hydrate/steps/writing/creation/writePackageJson.ts
@@ -54,7 +54,7 @@ export async function writePackageJson({
 			build: "tsc",
 			format: 'prettier "**/*" --ignore-unknown',
 			"format:write": "pnpm format --write",
-			lint: "eslint . --max-warnings 0 --report-unused-disable-directives",
+			lint: "eslint . .*js --max-warnings 0 --report-unused-disable-directives",
 			"lint:knip": "knip",
 			"lint:md":
 				'markdownlint "**/*.md" ".github/**/*.md" --rules sentences-per-line',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #537
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes the `pnpm run lint` command to explicitly include dotfiles. I don't like making the command more complex, but I couldn't figure out a way to get it to include dotfiles... fortunately, once [ESLint flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new) is usable, we can switch to that and remove the change to the `lint` script.

Filed https://github.com/azat-io/eslint-plugin-perfectionist/issues/22 as part of this.
