### PR TITLE
feat: use eslint-plugin-perfection's partition-by-comment

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -143,8 +143,8 @@ module.exports = {
 		"perfectionist/sort-objects": [
 			"error",
 			{
-				type: "natural",
 				order: "asc",
+				type: "natural",
 				"partition-by-comment": true,
 			},
 		],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -140,7 +140,6 @@ module.exports = {
 		"no-inner-declarations": "off",
 
 		// Stylistic concerns that don't interfere with Prettier
-		"padding-line-between-statements": "off",
 		"perfectionist/sort-objects": [
 			"error",
 			{

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,7 +22,6 @@ module.exports = {
 		"plugin:regexp/recommended",
 		"prettier",
 	],
-	/* eslint-disable perfectionist/sort-objects -- https://github.com/azat-io/eslint-plugin-perfectionist/issues/22 */
 	overrides: [
 		{
 			extends: ["plugin:markdown/recommended"],
@@ -142,6 +141,14 @@ module.exports = {
 
 		// Stylistic concerns that don't interfere with Prettier
 		"padding-line-between-statements": "off",
+		"perfectionist/sort-objects": [
+			"error",
+			{
+				type: "natural",
+				order: "asc",
+				"partition-by-comment": true,
+			},
+		],
 		"@typescript-eslint/padding-line-between-statements": [
 			"error",
 			{ blankLine: "always", next: "*", prev: "block-like" },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -140,18 +140,17 @@ module.exports = {
 		"no-inner-declarations": "off",
 
 		// Stylistic concerns that don't interfere with Prettier
-		"perfectionist/sort-objects": [
-			"error",
-			{
-				order: "asc",
-				type: "natural",
-				"partition-by-comment": true,
-			},
-		],
 		"@typescript-eslint/padding-line-between-statements": [
 			"error",
 			{ blankLine: "always", next: "*", prev: "block-like" },
 		],
+		"perfectionist/sort-objects": [
+			"error",
+			{
+				order: "asc",
+				"partition-by-comment": true,
+				type: "natural",
+			},
+		],
 	},
-	/* eslint-enable perfectionist/sort-objects */
 };

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"eslint-plugin-markdown": "^3.0.0",
 		"eslint-plugin-n": "^16.0.0",
 		"eslint-plugin-no-only-tests": "^3.1.0",
-		"eslint-plugin-perfectionist": "^1.1.2",
+		"eslint-plugin-perfectionist": "^1.4.0",
 		"eslint-plugin-regexp": "^1.15.0",
 		"eslint-plugin-vitest": "^0.2.2",
 		"eslint-plugin-yml": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ devDependencies:
     specifier: ^3.1.0
     version: 3.1.0
   eslint-plugin-perfectionist:
-    specifier: ^1.1.2
-    version: 1.1.2(eslint@8.40.0)(typescript@5.0.4)
+    specifier: ^1.4.0
+    version: 1.4.0(eslint@8.40.0)(typescript@5.0.4)
   eslint-plugin-regexp:
     specifier: ^1.15.0
     version: 1.15.0(eslint@8.40.0)
@@ -3284,8 +3284,8 @@ packages:
     engines: {node: '>=5.0.0'}
     dev: true
 
-  /eslint-plugin-perfectionist@1.1.2(eslint@8.40.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-JG/rS7VnH6hXjWAGO83xCHTK+tgGRJyaDk5wGv2qTpnS8Iw+TpzSj/gQSJ2WAPaQJ9hEMN4OvrrUO1mzikUNEg==}
+  /eslint-plugin-perfectionist@1.4.0(eslint@8.40.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-9gO+qmuU1DYzoYeN2D0PqYrI1FlqMPYGsZTWUWnWPrMQdFGFtq7eYraeQ57/8ffNBbVX6e6HvQOJ9iok9DfJvw==}
     peerDependencies:
       eslint: '>=8.0.0'
     dependencies:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #549
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the option directly, so we can remove the disable comments in the config. Yay!