### PR TITLE
fix: made @clack/prompts a full dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
+		"@clack/prompts": "^0.6.3",
 		"chalk": "^5.2.0",
 		"execa": "^7.1.1",
 		"js-yaml": "^4.1.0"
 	},
 	"devDependencies": {
-		"@clack/prompts": "^0.6.3",
 		"@octokit/request-error": "^3.0.3",
 		"@types/eslint": "^8.37.0",
 		"@types/git-url-parse": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@clack/prompts':
+    specifier: ^0.6.3
+    version: 0.6.3
   chalk:
     specifier: ^5.2.0
     version: 5.2.0
@@ -16,9 +19,6 @@ dependencies:
     version: 4.1.0
 
 devDependencies:
-  '@clack/prompts':
-    specifier: ^0.6.3
-    version: 0.6.3
   '@octokit/request-error':
     specifier: ^3.0.3
     version: 3.0.3
@@ -394,7 +394,7 @@ packages:
     dependencies:
       picocolors: 1.0.0
       sisteransi: 1.0.5
-    dev: true
+    dev: false
 
   /@clack/prompts@0.6.3:
     resolution: {integrity: sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==}
@@ -402,7 +402,7 @@ packages:
       '@clack/core': 0.3.2
       picocolors: 1.0.0
       sisteransi: 1.0.5
-    dev: true
+    dev: false
     bundledDependencies:
       - is-unicode-supported
 
@@ -5822,7 +5822,6 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -6429,7 +6428,7 @@ packages:
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: true
+    dev: false
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}

--- a/src/setup/steps/uninstallPackages.ts
+++ b/src/setup/steps/uninstallPackages.ts
@@ -1,6 +1,6 @@
 import { $ } from "execa";
 
 export async function uninstallPackages() {
-	await $`pnpm remove chalk execa js-yaml`;
-	await $`pnpm remove @clack/prompts @octokit/request-error @types/git-url-parse @types/js-yaml @types/prettier all-contributors-cli c8 git-remote-origin-url git-url-parse globby npm-user octokit replace-in-file title-case tsx -D`;
+	await $`pnpm remove @clack/prompts chalk execa js-yaml`;
+	await $`pnpm remove @octokit/request-error @types/git-url-parse @types/js-yaml @types/prettier all-contributors-cli c8 git-remote-origin-url git-url-parse globby npm-user octokit replace-in-file title-case tsx -D`;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #551
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Since it's used in hydration, it should be installed.