### PR TITLE
fix: put prettier back as a devDependency in setup

### DIFF
--- a/src/setup/steps/uninstallPackages.ts
+++ b/src/setup/steps/uninstallPackages.ts
@@ -3,4 +3,5 @@ import { $ } from "execa";
 export async function uninstallPackages() {
 	await $`pnpm remove @clack/prompts chalk execa git-remote-origin-url git-url-parse js-yaml npm-user octokit prettier replace-in-file title-case`;
 	await $`pnpm remove @octokit/request-error @types/git-url-parse @types/js-yaml @types/prettier all-contributors-cli c8 globby tsx -D`;
+	await $`pnpm add prettier -D`;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #566
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`prettier` needs to be demoted from a `dependency` to a `devDependency`. Right now it's just removed altogether.