### PR TITLE
fix: don't enable GitHub's advanced_security

### DIFF
--- a/src/setup/steps/hydrateRepositorySettings.ts
+++ b/src/setup/steps/hydrateRepositorySettings.ts
@@ -22,9 +22,6 @@ export async function hydrateRepositorySettings(
 		owner,
 		repo: repository,
 		security_and_analysis: {
-			advanced_security: {
-				status: "enabled",
-			},
 			secret_scanning: {
 				status: "enabled",
 			},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #654
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removing it fixes the 422 complaint for public repos.

I guess this would be useful for private repos, but that logic doesn't exist in this template.