### PR TITLE
fix: remove last hydrate/setup vestiges in setup

### DIFF
--- a/src/setup/setupWithInformation.ts
+++ b/src/setup/setupWithInformation.ts
@@ -77,6 +77,9 @@ export async function setupWithInformation({
 	if (values.skipUninstalls) {
 		skipSpinnerBlock(`Skipping uninstall of packages only used for setup.`);
 	} else {
-		await withSpinner(uninstallPackages, "removing packages only");
+		await withSpinner(
+			uninstallPackages,
+			"removing packages only used for setup",
+		);
 	}
 }

--- a/src/setup/steps/removeSetupScripts.ts
+++ b/src/setup/steps/removeSetupScripts.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 
 const globPaths = [
+	"./bin",
 	"./script",
 	"./src/hydrate",
 	"./src/setup",

--- a/src/setup/steps/updateLocalFiles.ts
+++ b/src/setup/steps/updateLocalFiles.ts
@@ -38,7 +38,7 @@ export async function updateLocalFiles({
 		[/"setup": ".*/g, ``, "./package.json"],
 
 		[/## Explainer.*## Usage/gs, `## Usage`, "./README.md"],
-		[/\n### Testing the Setup Script.*$/gs, "", "./.github/DEVELOPMENT.md"],
+		[/\n## The .+ Script.*$/gs, "", "./.github/DEVELOPMENT.md"],
 		[`,\n\t\t["src/setup/*.json"`, ``, "./cspell.json"],
 		[`\t\t"src/hydrate/index.ts",\n`, ``, "./knip.jsonc"],
 		[`\t\t"src/setup/index.ts",\n`, ``, "./knip.jsonc"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #660
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes a few more bits of setup info. Also fixes a string in the script.