### PR TITLE
fix: also run npx all-contributors-cli generate in setup

### DIFF
--- a/src/hydrate/index.ts
+++ b/src/hydrate/index.ts
@@ -9,7 +9,7 @@ import {
 import { runOrRestore } from "../shared/runOrRestore.js";
 import { clearUnnecessaryFiles } from "./steps/clearUnnecessaryFiles.js";
 import { detectExistingContributors } from "./steps/detectExistingContributors.js";
-import { finalizeDependencies as finalizeDependencies } from "./steps/finalizeDependencies.js";
+import { finalizeDependencies } from "./steps/finalizeDependencies.js";
 import { runCommand } from "./steps/runCommand.js";
 import { writeReadme } from "./steps/writeReadme.js";
 import { writeStructure } from "./steps/writing/writeStructure.js";

--- a/src/hydrate/steps/finalizeDependencies.ts
+++ b/src/hydrate/steps/finalizeDependencies.ts
@@ -57,7 +57,7 @@ export async function finalizeDependencies({
 
 	for (const command of [
 		`pnpm add ${devDependencies.map(atLatest).join(" ")} -D`,
-		`npx all-contributors generate`,
+		`npx all-contributors-cli generate`,
 		`pnpm uninstall all-contributors-cli all-contributors-for-repository -D`,
 		"pnpm run format:write",
 	]) {

--- a/src/setup/steps/updateAllContributorsTable.ts
+++ b/src/setup/steps/updateAllContributorsTable.ts
@@ -1,3 +1,4 @@
+import { $ } from "execa";
 import fs from "node:fs/promises";
 import prettier from "prettier";
 
@@ -22,4 +23,6 @@ export async function updateAllContributorsTable({
 			{ parser: "json" },
 		),
 	);
+
+	await $`npx all-contributors-cli generate`;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #663
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I think it's fine to run the command both in hydration and setup. It's not slow.