### PR TITLE
feat: allowed hydration directory to be empty

### DIFF
--- a/src/hydrate/steps/writing/creation/writePackageJson.test.ts
+++ b/src/hydrate/steps/writing/creation/writePackageJson.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { writePackageJson } from "./writePackageJson.js";
 
-const mockReadFileAsJson = vi.fn();
+const mockReadFileSafeAsJson = vi.fn();
 
-vi.mock("../../../../shared/readFileAsJson.js", () => ({
-	get readFileAsJson() {
-		return mockReadFileAsJson;
+vi.mock("../../../../shared/readFileSafeAsJson.js", () => ({
+	get readFileSafeAsJson() {
+		return mockReadFileSafeAsJson;
 	},
 }));
 
@@ -23,7 +23,7 @@ const values = {
 describe("writePackageJson", () => {
 	it("preserves existing dependencies when they exist", async () => {
 		const dependencies = { abc: "1.2.3" };
-		mockReadFileAsJson.mockResolvedValue({ dependencies });
+		mockReadFileSafeAsJson.mockResolvedValue({ dependencies });
 
 		const packageJson = await writePackageJson(values);
 
@@ -34,7 +34,7 @@ describe("writePackageJson", () => {
 
 	it("preserves existing devDependencies that aren't known to be unnecessary when they exist", async () => {
 		const devDependencies = { abc: "1.2.3", jest: "4.5.6" };
-		mockReadFileAsJson.mockResolvedValue({ devDependencies });
+		mockReadFileSafeAsJson.mockResolvedValue({ devDependencies });
 
 		const packageJson = await writePackageJson(values);
 
@@ -44,7 +44,7 @@ describe("writePackageJson", () => {
 	});
 
 	it("includes a release script when releases is true", async () => {
-		mockReadFileAsJson.mockResolvedValue({});
+		mockReadFileSafeAsJson.mockResolvedValue({});
 
 		const packageJson = await writePackageJson({
 			...values,
@@ -61,7 +61,7 @@ describe("writePackageJson", () => {
 	});
 
 	it("includes a test script when unitTests is true", async () => {
-		mockReadFileAsJson.mockResolvedValue({});
+		mockReadFileSafeAsJson.mockResolvedValue({});
 
 		const packageJson = await writePackageJson({
 			...values,

--- a/src/hydrate/steps/writing/creation/writePackageJson.ts
+++ b/src/hydrate/steps/writing/creation/writePackageJson.ts
@@ -1,4 +1,4 @@
-import { readFileAsJson } from "../../../../shared/readFileAsJson.js";
+import { readFileSafeAsJson } from "../../../../shared/readFileSafeAsJson.js";
 import { HydrationInputValues } from "../../../values/types.js";
 import { formatJson } from "./formatters/formatJson.js";
 
@@ -41,9 +41,8 @@ export async function writePackageJson({
 	| "repository"
 	| "unitTests"
 >) {
-	const existingPackageJson = (await readFileAsJson(
-		"./package.json",
-	)) as object;
+	const existingPackageJson =
+		((await readFileSafeAsJson("./package.json")) as null | object) ?? {};
 
 	return await formatJson({
 		// To start, copy over all existing package fields (e.g. "dependencies")

--- a/src/shared/ensureGitRepository.test.ts
+++ b/src/shared/ensureGitRepository.test.ts
@@ -1,0 +1,43 @@
+import chalk from "chalk";
+import { describe, expect, it, vi } from "vitest";
+
+import { ensureGitRepository } from "./ensureGitRepository.js";
+
+const mock$ = vi.fn();
+
+vi.mock("execa", () => ({
+	get $() {
+		return mock$;
+	},
+}));
+
+const mockLogLine = vi.fn();
+
+vi.mock("./cli/lines.js", () => ({
+	get logLine() {
+		return mockLogLine;
+	},
+}));
+
+describe("ensureGitRepository", () => {
+	it("does not run git init when git status succeeds", async () => {
+		mock$.mockResolvedValue(0);
+
+		await ensureGitRepository();
+
+		expect(mock$).toHaveBeenCalledTimes(1);
+		expect(mockLogLine).not.toHaveBeenCalled();
+	});
+
+	it("runs git init when git status fails", async () => {
+		mock$.mockRejectedValueOnce(1);
+
+		await ensureGitRepository();
+
+		expect(mock$).toHaveBeenCalledWith(["git init"]);
+		expect(mockLogLine).toHaveBeenCalledWith();
+		expect(mockLogLine).toHaveBeenCalledWith(
+			chalk.gray("Running `git init` to turn this into a Git repository."),
+		);
+	});
+});

--- a/src/shared/ensureGitRepository.ts
+++ b/src/shared/ensureGitRepository.ts
@@ -1,0 +1,17 @@
+import chalk from "chalk";
+import { $ } from "execa";
+
+import { logLine } from "./cli/lines.js";
+
+export async function ensureGitRepository() {
+	try {
+		await $`git status`;
+	} catch {
+		logLine();
+		logLine(
+			chalk.gray("Running `git init` to turn this into a Git repository."),
+		);
+
+		await $`git init`;
+	}
+}

--- a/src/shared/getDefaultSettings.ts
+++ b/src/shared/getDefaultSettings.ts
@@ -14,7 +14,7 @@ export async function getDefaultSettings() {
 		logLine();
 		logLine(
 			chalk.gray(
-				"Could not populate default owner and repository. Did not detect a Git repository with an origin. ",
+				"Could not populate default owner and repository. Did not detect an 'origin' remote.",
 			),
 		);
 

--- a/src/shared/runOrRestore.test.ts
+++ b/src/shared/runOrRestore.test.ts
@@ -67,7 +67,8 @@ describe("runOrRestore", () => {
 
 		expect(actual).toEqual(1);
 
-		expect(mock$).not.toHaveBeenCalled();
+		expect(mock$).toHaveBeenCalledWith(["git status"]);
+		expect(mock$).toHaveBeenCalledTimes(1);
 	});
 
 	it("returns 1 and restores the repository when run rejects, skipRestore is false, and shouldRestore is confirmed", async () => {
@@ -87,6 +88,8 @@ describe("runOrRestore", () => {
 
 		expect(actual).toEqual(1);
 
+		expect(mock$).toHaveBeenCalledWith(["git status"]);
 		expect(mock$).toHaveBeenCalledWith(["git restore ."]);
+		expect(mock$).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/shared/runOrRestore.ts
+++ b/src/shared/runOrRestore.ts
@@ -2,6 +2,7 @@ import * as prompts from "@clack/prompts";
 import chalk from "chalk";
 import { $ } from "execa";
 
+import { ensureGitRepository } from "./ensureGitRepository.js";
 import {
 	GetterDefaultInputValues,
 	InputValuesAndOctokit,
@@ -38,6 +39,8 @@ export async function runOrRestore({
 				"Let's collect some information to fill out repository details...",
 			),
 		);
+
+		await ensureGitRepository();
 
 		const { octokit, values } = await getInputValuesAndOctokit(args, defaults);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #669
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes split out of #668:

* If `git status` fails, runs `git init` to make the directory a repo
* Allows `package.json` to be empty, defaulting its contents to `{}`