### PR TITLE
feat: allow blank package.json in readFileSafeAsJson

### DIFF
--- a/src/initialize/steps/updateLocalFiles.test.ts
+++ b/src/initialize/steps/updateLocalFiles.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { updateLocalFiles } from "./updateLocalFiles.js";
+
+const mockReplaceInFile = vi.fn();
+
+vi.mock("replace-in-file", () => ({
+	get default() {
+		return mockReplaceInFile;
+	},
+}));
+
+const mockReadFileSafeAsJson = vi.fn();
+
+vi.mock("../../shared/readFileSafeAsJson.js", () => ({
+	get readFileSafeAsJson() {
+		return mockReadFileSafeAsJson;
+	},
+}));
+
+const stubOptions = {
+	description: "Stub description.",
+	npmAuthor: "stub-npm-author",
+	owner: "StubOwner",
+	repository: "stub-repository",
+	title: "Stub Title",
+};
+
+describe("updateLocalFiles", () => {
+	it("throws a wrapping error when replaceInFiles rejects", async () => {
+		const error = new Error("Oh no!");
+
+		mockReadFileSafeAsJson.mockResolvedValue({});
+		mockReplaceInFile.mockRejectedValue(error);
+
+		await expect(async () => {
+			await updateLocalFiles(stubOptions);
+		}).rejects.toThrowErrorMatchingInlineSnapshot(
+			'"Failed to replace /Template TypeScript Node Package/g with Stub Title in ./.github/**/*,./*.*"',
+		);
+	});
+
+	it("replaces using the common replacements when the existing package data is empty", async () => {
+		mockReadFileSafeAsJson.mockResolvedValue({});
+		mockReplaceInFile.mockResolvedValue([]);
+
+		await updateLocalFiles(stubOptions);
+
+		expect(mockReplaceInFile.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /Template TypeScript Node Package/g,
+			      "to": "Stub Title",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /JoshuaKGoldberg/g,
+			      "to": "StubOwner",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /template-typescript-node-package/g,
+			      "to": "stub-repository",
+			    },
+			  ],
+			  [
+			    {
+			      "files": ".eslintrc.cjs",
+			      "from": /\\\\/\\\\\\*\\\\n\\.\\+\\\\\\*\\\\/\\\\n\\\\n/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"author": "\\.\\+"/g,
+			      "to": "\\"author\\": \\"stub-npm-author\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"bin": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"initialize:test": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"initialize": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"migrate:test": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./README.md",
+			      "from": /## Getting Started\\.\\*## Development/gs,
+			      "to": "## Development",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./.github/DEVELOPMENT.md",
+			      "from": /\\\\n## Setup Scripts\\.\\*\\$/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/initialize/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/migrate/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/index.ts!\\", \\"script/initialize*.js\\"]",
+			      "to": "\\"src/index.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
+			      "to": "\\"src/**/*.ts!\\"",
+			    },
+			  ],
+			]
+		`);
+	});
+
+	it("replaces using the extra replacements when the existing package data is full", async () => {
+		mockReadFileSafeAsJson.mockResolvedValue({
+			description: "Existing description",
+			version: "1.2.3",
+		});
+		mockReplaceInFile.mockResolvedValue([]);
+
+		await updateLocalFiles(stubOptions);
+
+		expect(mockReplaceInFile.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /Template TypeScript Node Package/g,
+			      "to": "Stub Title",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /JoshuaKGoldberg/g,
+			      "to": "StubOwner",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /template-typescript-node-package/g,
+			      "to": "stub-repository",
+			    },
+			  ],
+			  [
+			    {
+			      "files": ".eslintrc.cjs",
+			      "from": /\\\\/\\\\\\*\\\\n\\.\\+\\\\\\*\\\\/\\\\n\\\\n/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"author": "\\.\\+"/g,
+			      "to": "\\"author\\": \\"stub-npm-author\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"bin": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"initialize:test": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"initialize": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"migrate:test": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./README.md",
+			      "from": /## Getting Started\\.\\*## Development/gs,
+			      "to": "## Development",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./.github/DEVELOPMENT.md",
+			      "from": /\\\\n## Setup Scripts\\.\\*\\$/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/initialize/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/migrate/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/index.ts!\\", \\"script/initialize*.js\\"]",
+			      "to": "\\"src/index.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
+			      "to": "\\"src/**/*.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /Existing description/g,
+			      "to": "Stub description.",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"version": "1\\.2\\.3"/g,
+			      "to": "\\"version\\": \\"0.0.0\\"",
+			    },
+			  ],
+			]
+		`);
+	});
+});

--- a/src/initialize/steps/updateLocalFiles.ts
+++ b/src/initialize/steps/updateLocalFiles.ts
@@ -1,6 +1,6 @@
 import replaceInFile from "replace-in-file";
 
-import { readFileAsJson } from "../../shared/readFileAsJson.js";
+import { readFileSafeAsJson } from "../../shared/readFileSafeAsJson.js";
 
 interface UpdateLocalFilesOptions {
 	description: string;
@@ -22,11 +22,11 @@ export async function updateLocalFiles({
 	repository,
 	title,
 }: UpdateLocalFilesOptions) {
-	const existingPackage = (await readFileAsJson(
+	const existingPackage = (await readFileSafeAsJson(
 		"./package.json",
 	)) as ExistingPackageData;
 
-	const replacements: [RegExp | string, string, string?][] = [
+	const replacements = [
 		[/Template TypeScript Node Package/g, title],
 		[/JoshuaKGoldberg/g, owner],
 		[/template-typescript-node-package/g, repository],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #678
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds unit test coverage too.