### PR TITLE
fix: allow package.json to be empty in updateLocalFiles

### DIFF
--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -40,7 +40,142 @@ describe("updateLocalFiles", () => {
 		);
 	});
 
-	it("replaces using the common replacements when the existing package data is empty", async () => {
+	it("replaces using the common replacements when the existing package data is null", async () => {
+		mockReadFileSafeAsJson.mockResolvedValue(null);
+		mockReplaceInFile.mockResolvedValue([]);
+
+		await updateLocalFiles(stubOptions);
+
+		expect(mockReplaceInFile.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /Template TypeScript Node Package/g,
+			      "to": "Stub Title",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /JoshuaKGoldberg/g,
+			      "to": "StubOwner",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /template-typescript-node-package/g,
+			      "to": "stub-repository",
+			    },
+			  ],
+			  [
+			    {
+			      "files": ".eslintrc.cjs",
+			      "from": /\\\\/\\\\\\*\\\\n\\.\\+\\\\\\*\\\\/\\\\n\\\\n/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"author": "\\.\\+"/g,
+			      "to": "\\"author\\": \\"stub-npm-author\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"bin": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"create:test": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"initialize:test": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"initialize": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"migrate:test": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./README.md",
+			      "from": /## Getting Started\\.\\*## Development/gs,
+			      "to": "## Development",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./.github/DEVELOPMENT.md",
+			      "from": /\\\\n## Setup Scripts\\.\\*\\$/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/initialize/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/migrate/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/index.ts!\\", \\"script/initialize*.js\\"]",
+			      "to": "\\"src/index.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
+			      "to": "\\"src/**/*.ts!\\"",
+			    },
+			  ],
+			]
+		`);
+	});
+
+	it("replaces using the common replacements when the existing package data is an empty object", async () => {
 		mockReadFileSafeAsJson.mockResolvedValue({});
 		mockReplaceInFile.mockResolvedValue([]);
 

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -22,9 +22,8 @@ export async function updateLocalFiles({
 	repository,
 	title,
 }: UpdateLocalFilesOptions) {
-	const existingPackage = (await readFileSafeAsJson(
-		"./package.json",
-	)) as ExistingPackageData;
+	const existingPackage = ((await readFileSafeAsJson("./package.json")) ??
+		{}) as ExistingPackageData;
 
 	const replacements = [
 		[/Template TypeScript Node Package/g, title],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #685
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Yet another case where a non-existent (or empty) `package.json` caused issues.