### PR TITLE
fix: respect stripped versions of outcome labels

### DIFF
--- a/src/steps/labels/getExistingEquivalentLabel.ts
+++ b/src/steps/labels/getExistingEquivalentLabel.ts
@@ -13,7 +13,8 @@ export function getExistingEquivalentLabel(
 		return (
 			existingLabel === outcomeLabel ||
 			existingLabel === outcomeTrimmed ||
-			aliases.get(existingLabel) === outcomeLabel
+			aliases.get(existingLabel) === outcomeLabel ||
+			existingLabel.replace(/\w+: (\w+)/, "$1") === outcomeLabel
 		);
 	});
 }

--- a/src/steps/labels/initializeRepositoryLabels.test.ts
+++ b/src/steps/labels/initializeRepositoryLabels.test.ts
@@ -35,12 +35,11 @@ describe("migrateRepositoryLabels", () => {
 		await initializeRepositoryLabels();
 
 		expect(mock$).toHaveBeenCalledWith(
-			["gh label ", " ", " --color ", " --description ", "", "--name"],
+			["gh label ", " ", " --color ", " --description ", ""],
 			"create",
 			"abc",
 			"000000",
 			"def ghi",
-			"other",
 		);
 	});
 
@@ -58,11 +57,12 @@ describe("migrateRepositoryLabels", () => {
 		await initializeRepositoryLabels();
 
 		expect(mock$).toHaveBeenCalledWith(
-			["gh label ", " ", " --color ", " --description ", ""],
+			["gh label ", " ", " --color ", " --description ", " --name ", ""],
 			"edit",
 			"abc",
 			"000000",
 			"def ghi",
+			"abc",
 		);
 	});
 

--- a/src/steps/labels/initializeRepositoryLabels.test.ts
+++ b/src/steps/labels/initializeRepositoryLabels.test.ts
@@ -35,11 +35,12 @@ describe("migrateRepositoryLabels", () => {
 		await initializeRepositoryLabels();
 
 		expect(mock$).toHaveBeenCalledWith(
-			["gh label ", " ", " --color ", " --description ", ""],
+			["gh label ", " ", " --color ", " --description ", "", "--name"],
 			"create",
 			"abc",
 			"000000",
 			"def ghi",
+			"other",
 		);
 	});
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #687
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Also checks for outcome labels whose stripped version (no prefix) matches the existing label.