### PR TITLE
fix: add missing id-token permissions to release.yml template

### DIFF
--- a/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
@@ -27,6 +27,7 @@ interface WorkflowFileOn {
 
 interface WorkflowFilePermissions {
 	contents?: string;
+	"id-token"?: string;
 	"pull-requests"?: string;
 }
 

--- a/src/steps/writing/creation/dotGitHub/workflows.ts
+++ b/src/steps/writing/creation/dotGitHub/workflows.ts
@@ -158,6 +158,7 @@ export function createWorkflows(options: Options) {
 				},
 				permissions: {
 					contents: "write",
+					"id-token": "write",
 				},
 				steps: [
 					{


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #716
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

It was included in the original PR but I'd never added it to the template.