### PR TITLE
fix: chmod ug+x .husky/pre-commit after writing structure

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -7,7 +7,7 @@
 		"src/migrate/index.ts",
 		"script/*e2e.js"
 	],
-	"ignoreBinaries": ["gh"],
+	"ignoreBinaries": ["chmod", "gh"],
 	"ignoreExportsUsedInFile": {
 		"interface": true,
 		"type": true

--- a/src/steps/writing/writeStructure.ts
+++ b/src/steps/writing/writeStructure.ts
@@ -1,7 +1,12 @@
+import { $ } from "execa";
+
 import { Options } from "../../shared/types.js";
 import { createStructure } from "./creation/index.js";
 import { writeStructureWorker } from "./writeStructureWorker.js";
 
 export async function writeStructure(options: Options) {
 	await writeStructureWorker(await createStructure(options), ".");
+
+	// https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues/718
+	await $`chmod ug+x .husky/pre-commit`;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #718
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies the suggested fix from https://github.com/typicode/husky/issues/1177 of manually changing the file's mode with `chmod`.