### PR TITLE
fix: suggest a re-run command instead of pnpm initialize after offline creation

### DIFF
--- a/src/create/createRerunSuggestion.test.ts
+++ b/src/create/createRerunSuggestion.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { createRerunSuggestion } from "./createRerunSuggestion.js";
+
+describe("createRerunSuggestion", () => {
+	it("includes key-value pairs with mixed truthy and falsy values", () => {
+		const actual = createRerunSuggestion("initialize", {
+			author: "TestAuthor",
+			base: "everything",
+			createRepository: true,
+			description: "Test description.",
+			email: "test@test.com",
+			excludeCompliance: true,
+			excludeContributors: true,
+			excludeLintJson: true,
+			excludeLintKnip: true,
+			excludeLintMd: false,
+			excludeLintPackageJson: true,
+			excludeLintPackages: false,
+			excludeLintPerfectionist: true,
+			excludeLintSpelling: false,
+			excludeLintYml: false,
+			excludeReleases: false,
+			excludeRenovate: undefined,
+			excludeTests: undefined,
+			funding: undefined,
+			owner: "TestOwner",
+			repository: "test-repository",
+			skipGitHubApi: true,
+			skipInstall: true,
+			skipRemoval: true,
+			skipRestore: undefined,
+			skipUninstall: undefined,
+			title: "Test Title",
+		});
+
+		expect(actual).toMatchInlineSnapshot(
+			'"npx template-typescript-node-package --mode initialize --description \\"Test description.\\" --exclude-compliance true --owner TestOwner --repository test-repository --title \\"Test Title\\""',
+		);
+	});
+});

--- a/src/create/createRerunSuggestion.test.ts
+++ b/src/create/createRerunSuggestion.test.ts
@@ -35,7 +35,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			'"npx template-typescript-node-package --mode initialize --description \\"Test description.\\" --exclude-compliance true --owner TestOwner --repository test-repository --title \\"Test Title\\""',
+			'"npx template-typescript-node-package --mode initialize --author TestAuthor --base everything --create-repository true --description \\"Test description.\\" --email test@test.com --exclude-compliance true --exclude-contributors true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title \\"Test Title\\""',
 		);
 	});
 });

--- a/src/create/createRerunSuggestion.ts
+++ b/src/create/createRerunSuggestion.ts
@@ -1,0 +1,23 @@
+import { Mode } from "../bin/mode.js";
+import { allArgOptions } from "../shared/options/args.js";
+import { Options } from "../shared/types.js";
+
+function getFirstMatchingArg(key: string) {
+	return Object.keys(allArgOptions).find(
+		(arg) => arg.replaceAll("-", "") === key.toLowerCase(),
+	);
+}
+
+export function createRerunSuggestion(mode: Mode, options: Options): string {
+	const args = Object.entries(options)
+		.filter(([, value]) => !!value)
+		.map(([key, value]) => {
+			const valueStringified = `${value}`;
+			return `--${getFirstMatchingArg(key)} ${
+				valueStringified.includes(" ") ? `"${value}"` : value
+			}`;
+		})
+		.join(" ");
+
+	return `npx template-typescript-node-package --mode ${mode} ${args}`;
+}

--- a/src/create/index.ts
+++ b/src/create/index.ts
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import { outro } from "../shared/cli/outro.js";
 import { readOptions } from "../shared/options/readOptions.js";
 import { runOrRestore } from "../shared/runOrRestore.js";
+import { createRerunSuggestion } from "./createRerunSuggestion.js";
 import { createWithOptions } from "./createWithOptions.js";
 
 export async function create(args: string[]) {
@@ -38,7 +39,11 @@ export async function create(args: string[]) {
 									"Consider creating a GitHub repository from the new directory:",
 								lines: [
 									`cd ${inputs.options.repository}`,
-									`pnpm run initialize`,
+									createRerunSuggestion("initialize", {
+										...inputs.options,
+										skipGitHubApi: false,
+										skipInstall: false,
+									}),
 									`git add -A`,
 									`git commit -m "feat: initial commit ✨"`,
 									`git push -u origin main`,

--- a/src/shared/options/augmentOptionsWithExcludes.test.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.test.ts
@@ -25,7 +25,7 @@ const optionsBase = {
 	funding: undefined,
 	owner: "",
 	repository: "",
-	skipApi: false,
+	skipGitHubApi: false,
 	skipInstall: undefined,
 	skipRemoval: undefined,
 	skipRestore: undefined,

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -91,7 +91,7 @@ export async function readOptions(args: string[]): Promise<OctokitAndOptions> {
 			),
 			owner,
 			repository: repository,
-			skipApi: !!values["skip-github-api"],
+			skipGitHubApi: !!values["skip-github-api"],
 			skipInstall: !!values["skip-install"],
 			skipRemoval: !!values["skip-removal"],
 			skipRestore: values["skip-restore"] as boolean | undefined,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,7 +41,7 @@ export interface Options {
 	funding: string | undefined;
 	owner: string;
 	repository: string;
-	skipApi: boolean;
+	skipGitHubApi: boolean;
 	skipInstall: boolean | undefined;
 	skipRemoval: boolean | undefined;
 	skipRestore: boolean | undefined;

--- a/src/steps/finalizeDependencies.test.ts
+++ b/src/steps/finalizeDependencies.test.ts
@@ -42,7 +42,7 @@ const options = {
 	funding: undefined,
 	owner: "StubOwner",
 	repository: "stub-repository",
-	skipApi: false,
+	skipGitHubApi: false,
 	skipInstall: undefined,
 	skipRemoval: undefined,
 	skipRestore: undefined,

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -41,7 +41,7 @@ const options = {
 	funding: undefined,
 	owner: "StubOwner",
 	repository: "stub-repository",
-	skipApi: false,
+	skipGitHubApi: false,
 	skipInstall: undefined,
 	skipRemoval: undefined,
 	skipRestore: undefined,

--- a/src/steps/writeReadme.test.ts
+++ b/src/steps/writeReadme.test.ts
@@ -45,7 +45,7 @@ const options = {
 	funding: undefined,
 	owner: "TestOwner",
 	repository: "test-repository",
-	skipApi: false,
+	skipGitHubApi: false,
 	skipInstall: true,
 	skipRemoval: false,
 	skipRestore: false,

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -33,7 +33,7 @@ const options = {
 	funding: undefined,
 	owner: "test-owner",
 	repository: "test-repository",
-	skipApi: false,
+	skipGitHubApi: false,
 	skipInstall: undefined,
 	skipRemoval: undefined,
 	skipRestore: undefined,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #722
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Instead of `pnpm initialize`, adds a re-run suggestion that takes in the parsed options and re-prints them in the CLI. It hardcodes `skip-github-api` and `skip-install` to `false` because they're needed for the new repo.