### PR TITLE
fix: initialize git remote if needed

### DIFF
--- a/src/steps/initializeGitHubRepository/index.ts
+++ b/src/steps/initializeGitHubRepository/index.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "octokit";
 
 import { Options } from "../../shared/types.js";
+import { initializeGitRemote } from "../initializeGitRemote.js";
 import { initializeRepositorySettings } from "../initializeRepositorySettings.js";
 import { initializeBranchProtectionSettings } from "./initializeBranchProtectionSettings.js";
 import { initializeRepositoryLabels } from "./labels/initializeRepositoryLabels.js";
@@ -9,7 +10,8 @@ export async function initializeGitHubRepository(
 	octokit: Octokit,
 	options: Options,
 ) {
+	await initializeGitRemote(options);
+	await initializeRepositorySettings(octokit, options);
 	await initializeBranchProtectionSettings(octokit, options);
 	await initializeRepositoryLabels();
-	await initializeRepositorySettings(octokit, options);
 }

--- a/src/steps/initializeGitRemote.test.ts
+++ b/src/steps/initializeGitRemote.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { initializeGitRemote } from "./initializeGitRemote.js";
+
+const mock$ = vi.fn();
+
+vi.mock("execa", () => ({
+	get $() {
+		return mock$;
+	},
+}));
+
+const options = {
+	owner: "TestOwner",
+	repository: "test-repository",
+};
+
+describe("initializeGitRemote", () => {
+	it("does not add an origin or fetch when remotes already includes origin", async () => {
+		mock$.mockResolvedValue({
+			stdout: "origin",
+		});
+
+		await initializeGitRemote(options);
+
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "git remote",
+			    ],
+			  ],
+			]
+		`);
+	});
+
+	it("add an origin and fetch when remotes does not include origin", async () => {
+		mock$.mockResolvedValue({
+			stdout: "",
+		});
+
+		await initializeGitRemote(options);
+
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "git remote",
+			    ],
+			  ],
+			  [
+			    [
+			      "git remote add origin https://github.com/",
+			      "/",
+			      "",
+			    ],
+			    "TestOwner",
+			    "test-repository",
+			  ],
+			  [
+			    [
+			      "git fetch",
+			    ],
+			  ],
+			]
+		`);
+	});
+});

--- a/src/steps/initializeGitRemote.ts
+++ b/src/steps/initializeGitRemote.ts
@@ -1,0 +1,17 @@
+import { $ } from "execa";
+
+import { Options } from "../shared/types.js";
+
+type InitializeRepositorySettings = Pick<Options, "owner" | "repository">;
+
+export async function initializeGitRemote({
+	owner,
+	repository,
+}: InitializeRepositorySettings) {
+	const remotes = (await $`git remote`).stdout.trim().split("\n");
+
+	if (!remotes.includes("origin")) {
+		await $`git remote add origin https://github.com/${owner}/${repository}`;
+		await $`git fetch`;
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #722
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In `initializeGitHubRepository`, if there isn't yet an `origin` remote per `git remote`, adds one.